### PR TITLE
feat: add --list-tools and improve tool discoverability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,14 @@ AGENT_API_KEY=your-agent-api-key
 # AGENT_SYSTEM_PROMPT_FILE=
 # AGENT_LOG_LEVEL=INFO
 # AGENT_LLM_BACKEND=anthropic
+# AGENT_EXTERNAL_URL=
+
+# Tools are off by default. Enable by name or group (comma-separated).
+# Groups:
+#   bash        — shell command execution with timeout
+#   filesystem  — read_file, write_file, edit_file, list_directory, search_files
+# Individual tools: bash, read_file, write_file, edit_file, list_directory, search_files
+# Examples:
+#   AGENT_TOOLS=bash,filesystem      # all tools
+#   AGENT_TOOLS=bash,read_file       # shell + read-only file access
+# AGENT_TOOLS=

--- a/src/agentlings/__main__.py
+++ b/src/agentlings/__main__.py
@@ -1,11 +1,45 @@
 """CLI entry point for the agentling server."""
 
+import sys
+
 
 def main() -> None:
-    """Start the agentling HTTP server."""
+    """Start the agentling HTTP server, or show tool info with ``--list-tools``."""
+    if "--list-tools" in sys.argv:
+        _list_tools()
+        return
+
     from agentlings.server import run
 
     run()
+
+
+def _list_tools() -> None:
+    from agentlings.tools.builtins import BUILTIN_REGISTRY
+    from agentlings.tools.registry import TOOL_GROUPS
+
+    print("Available tool groups:\n")
+    for group, tools in TOOL_GROUPS.items():
+        print(f"  {group}")
+        for tool in tools:
+            desc = BUILTIN_REGISTRY[tool]["description"]
+            print(f"    {tool:20s} {desc}")
+        print()
+
+    standalone = set(BUILTIN_REGISTRY.keys())
+    for tools in TOOL_GROUPS.values():
+        standalone -= set(tools)
+    if standalone:
+        print("Standalone tools:\n")
+        for name in sorted(standalone):
+            desc = BUILTIN_REGISTRY[name]["description"]
+            print(f"  {name:22s} {desc}")
+        print()
+
+    print("Enable via AGENT_TOOLS env var (comma-separated).")
+    print("Examples:")
+    print("  AGENT_TOOLS=bash,filesystem")
+    print("  AGENT_TOOLS=bash,read_file")
 
 
 if __name__ == "__main__":

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -74,6 +74,12 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
     tools = ToolRegistry()
     tools.register_tools(config.enabled_tools)
 
+    if not tools.tool_names():
+        logger.warning(
+            "no tools enabled — set AGENT_TOOLS to enable tools "
+            "(run 'agentling --list-tools' to see available options)"
+        )
+
     llm = create_llm_client(
         backend=config.agent_llm_backend,
         api_key=config.anthropic_api_key,


### PR DESCRIPTION
Tools were not obvious from configuration alone.

- `agentling --list-tools` shows all available groups and tools with descriptions
- Startup logs a warning when no tools are enabled, with a hint to `--list-tools`
- `.env.example` documents groups, individual tools, and example configurations