### PR TITLE
refactor: migrate to a2a-sdk 1.0 with 0.3 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Lightweight A2A + MCP single-process agent framework"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.52",
-    "a2a-sdk>=0.3.25,<1.0",
+    "a2a-sdk>=1.0.0",
     "starlette>=0.46",
     "uvicorn[standard]>=0.34",
     "pydantic>=2.11",
@@ -27,7 +27,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.25",
     "httpx>=0.28",
-    "a2a-sdk>=0.3.25,<1.0",
+    "a2a-sdk>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/agentlings/protocol/a2a.py
+++ b/src/agentlings/protocol/a2a.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import json
 import logging
 
+from a2a.helpers.proto_helpers import new_text_message
 from a2a.server.agent_execution import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events import EventQueue
-from a2a.utils import new_agent_text_message
+from a2a.types import Message, Role
 
 from agentlings.config import AgentConfig
 from agentlings.core.loop import MessageLoop
@@ -31,6 +32,26 @@ from agentlings.core.task import (
 from agentlings.protocol.a2a_task_store import task_state_to_a2a_task
 
 logger = logging.getLogger(__name__)
+
+
+def _agent_text_message(
+    text: str,
+    *,
+    context_id: str | None = None,
+    task_id: str | None = None,
+) -> Message:
+    """Build an agent-role ``Message`` proto carrying a single text part.
+
+    Replaces the removed ``a2a.utils.new_agent_text_message`` helper. The
+    proto ``Message`` requires a ``message_id`` and has no field presence on
+    string fields, so empty-string defaults are used when ids are unset.
+    """
+    return new_text_message(
+        text,
+        context_id=context_id or "",
+        task_id=task_id or "",
+        role=Role.ROLE_AGENT,
+    )
 
 
 class AgentlingExecutor(AgentExecutor):
@@ -76,7 +97,7 @@ class AgentlingExecutor(AgentExecutor):
             # Surface as a plain agent message — there is no live Task on this
             # context that the caller can latch onto (it's someone else's).
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     _format_busy(e),
                     context_id=context_id,
                 )
@@ -86,7 +107,7 @@ class AgentlingExecutor(AgentExecutor):
         except Exception:  # noqa: BLE001
             logger.exception("error processing A2A message")
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     "Internal error processing request.",
                     context_id=context_id,
                 )
@@ -98,7 +119,7 @@ class AgentlingExecutor(AgentExecutor):
             # Fast path — return the final response text as a Message event.
             response_text = _extract_text(state.content)
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     response_text,
                     context_id=state.context_id,
                     task_id=state.task_id,
@@ -128,7 +149,7 @@ class AgentlingExecutor(AgentExecutor):
         task_id = context.task_id
         if not task_id:
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     "CancelTask requires a task_id.",
                     context_id=context.context_id,
                 )
@@ -140,7 +161,7 @@ class AgentlingExecutor(AgentExecutor):
             state = await self._engine.cancel(task_id=task_id)
         except TaskNotFoundError:
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     f"Task {task_id} not found.",
                     context_id=context.context_id,
                 )
@@ -150,7 +171,7 @@ class AgentlingExecutor(AgentExecutor):
         except Exception:  # noqa: BLE001
             logger.exception("cancel failed for task %s", task_id)
             await event_queue.enqueue_event(
-                new_agent_text_message(
+                _agent_text_message(
                     "Internal error during cancel.",
                     context_id=context.context_id,
                 )

--- a/src/agentlings/protocol/a2a_task_store.py
+++ b/src/agentlings/protocol/a2a_task_store.py
@@ -18,13 +18,14 @@ from typing import Any
 from a2a.server.context import ServerCallContext
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import (
+    ListTasksRequest,
+    ListTasksResponse,
     Message,
     Part,
     Role,
     Task,
     TaskState as A2ATaskState,
     TaskStatus as A2ATaskStatus,
-    TextPart,
 )
 
 from agentlings.core.task import (
@@ -37,13 +38,12 @@ from agentlings.core.task import (
 logger = logging.getLogger(__name__)
 
 
-# Mapping from our internal task lifecycle states to the A2A wire enum.
-_STATE_MAP: dict[TaskStatus, A2ATaskState] = {
-    TaskStatus.WORKING: A2ATaskState.working,
-    TaskStatus.CANCELLING: A2ATaskState.working,
-    TaskStatus.COMPLETED: A2ATaskState.completed,
-    TaskStatus.FAILED: A2ATaskState.failed,
-    TaskStatus.CANCELLED: A2ATaskState.canceled,
+_STATE_MAP: dict[TaskStatus, int] = {
+    TaskStatus.WORKING: A2ATaskState.TASK_STATE_WORKING,
+    TaskStatus.CANCELLING: A2ATaskState.TASK_STATE_WORKING,
+    TaskStatus.COMPLETED: A2ATaskState.TASK_STATE_COMPLETED,
+    TaskStatus.FAILED: A2ATaskState.TASK_STATE_FAILED,
+    TaskStatus.CANCELLED: A2ATaskState.TASK_STATE_CANCELED,
 }
 
 
@@ -58,19 +58,21 @@ def task_state_to_a2a_task(state: TaskState) -> Task:
     if state.status == TaskStatus.COMPLETED and state.content:
         text = _extract_text(state.content)
         if text:
-            history.append(Message(
-                role=Role.agent,
-                parts=[Part(root=TextPart(text=text))],
-                context_id=state.context_id,
-                task_id=state.task_id,
-                message_id=f"{state.task_id}-final",
-            ))
+            history.append(
+                Message(
+                    role=Role.ROLE_AGENT,
+                    parts=[Part(text=text)],
+                    context_id=state.context_id,
+                    task_id=state.task_id,
+                    message_id=f"{state.task_id}-final",
+                )
+            )
 
-    status_message: Message | None = None
+    status_kwargs: dict[str, Any] = {"state": _STATE_MAP[state.status]}
     if state.error and state.status in (TaskStatus.FAILED, TaskStatus.CANCELLED):
-        status_message = Message(
-            role=Role.agent,
-            parts=[Part(root=TextPart(text=state.error))],
+        status_kwargs["message"] = Message(
+            role=Role.ROLE_AGENT,
+            parts=[Part(text=state.error)],
             context_id=state.context_id,
             task_id=state.task_id,
             message_id=f"{state.task_id}-status",
@@ -79,14 +81,8 @@ def task_state_to_a2a_task(state: TaskState) -> Task:
     return Task(
         id=state.task_id,
         context_id=state.context_id,
-        status=A2ATaskStatus(
-            state=_STATE_MAP[state.status],
-            message=status_message,
-        ),
+        status=A2ATaskStatus(**status_kwargs),
         history=history,
-        artifacts=[],
-        kind="task",
-        metadata=None,
     )
 
 
@@ -137,3 +133,18 @@ class EngineTaskStore(TaskStore):
     ) -> None:
         """No-op. Retention follows the engine's lifecycle, not SDK calls."""
         logger.debug("EngineTaskStore.delete ignored for task %s", task_id)
+
+    async def list(
+        self,
+        params: ListTasksRequest,
+        context: ServerCallContext | None = None,
+    ) -> ListTasksResponse:
+        """Return an empty listing — the engine doesn't expose a task index.
+
+        The SDK's ``ListTasks`` RPC is optional; agentling doesn't advertise
+        the capability, so callers shouldn't invoke this. We return an empty
+        response rather than raise so the handler stays well-behaved if a
+        request slips through.
+        """
+        logger.debug("EngineTaskStore.list returning empty response")
+        return ListTasksResponse()

--- a/src/agentlings/protocol/agent_card.py
+++ b/src/agentlings/protocol/agent_card.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from a2a.types import (
     AgentCapabilities,
     AgentCard,
+    AgentInterface,
     AgentSkill,
     APIKeySecurityScheme,
+    SecurityRequirement,
+    SecurityScheme,
+    StringList,
 )
+from a2a.utils.constants import PROTOCOL_VERSION_1_0, TransportProtocol
 
 from agentlings.config import AgentConfig
 
@@ -35,7 +40,7 @@ def generate_agent_card(config: AgentConfig) -> AgentCard:
                 id=s.id,
                 name=s.name,
                 description=s.description,
-                tags=s.tags,
+                tags=list(s.tags),
             )
             for s in config.skills
         ]
@@ -52,18 +57,27 @@ def generate_agent_card(config: AgentConfig) -> AgentCard:
     return AgentCard(
         name=config.agent_name,
         description=config.agent_description,
-        url=url,
         version="0.1.0",
+        supported_interfaces=[
+            AgentInterface(
+                url=url,
+                protocol_binding=TransportProtocol.JSONRPC,
+                protocol_version=PROTOCOL_VERSION_1_0,
+            ),
+        ],
         skills=skills,
-        capabilities=AgentCapabilities(streaming=False, pushNotifications=False),
-        defaultInputModes=["text"],
-        defaultOutputModes=["text"],
-        securitySchemes={
-            "apiKey": APIKeySecurityScheme(
-                type="apiKey",
-                in_="header",
-                name="X-API-Key",
+        capabilities=AgentCapabilities(streaming=False, push_notifications=False),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        security_schemes={
+            "apiKey": SecurityScheme(
+                api_key_security_scheme=APIKeySecurityScheme(
+                    location="header",
+                    name="X-API-Key",
+                )
             )
         },
-        security=[{"apiKey": []}],
+        security_requirements=[
+            SecurityRequirement(schemes={"apiKey": StringList(list=[])})
+        ],
     )

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -8,8 +8,9 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
 import uvicorn
-from a2a.server.apps.jsonrpc.starlette_app import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -121,11 +122,7 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
     request_handler = DefaultRequestHandler(
         agent_executor=executor,
         task_store=EngineTaskStore(loop.engine),
-    )
-
-    a2a_app = A2AStarletteApplication(
         agent_card=agent_card,
-        http_handler=request_handler,
     )
 
     mcp_server = create_mcp_server(loop=loop, agent_card=agent_card, config=config)
@@ -196,8 +193,24 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
                     except asyncio.CancelledError:
                         pass
 
+    jsonrpc_routes = create_jsonrpc_routes(
+        request_handler=request_handler,
+        rpc_url="/a2a",
+        enable_v0_3_compat=True,
+    )
+    agent_card_routes = create_agent_card_routes(agent_card=agent_card)
+    # The 0.3 well-known path is ``/.well-known/agent.json``; 1.0 uses
+    # ``/.well-known/agent-card.json``. Expose both so existing 0.3 clients
+    # continue to discover the card.
+    legacy_card_routes = create_agent_card_routes(
+        agent_card=agent_card, card_url="/.well-known/agent.json"
+    )
+
     routes = [
         Route("/mcp", mcp_endpoint, methods=["GET", "POST", "DELETE"]),
+        *jsonrpc_routes,
+        *agent_card_routes,
+        *legacy_card_routes,
     ]
 
     middleware = [
@@ -209,8 +222,6 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         middleware=middleware,
         lifespan=lifespan,
     )
-
-    a2a_app.add_routes_to_app(app, rpc_url="/a2a")
 
     return app
 

--- a/tests/integration/a2a_client.py
+++ b/tests/integration/a2a_client.py
@@ -6,10 +6,22 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
-from a2a.client.client_factory import ClientFactory
-from a2a.client.middleware import ClientCallContext, ClientCallInterceptor
-from a2a.types import AgentCard, Message, Part, Role, TextPart
-from a2a.utils import get_message_text
+from a2a.client import (
+    ClientCallContext,
+    ClientCallInterceptor,
+    ClientConfig,
+    create_client,
+)
+from a2a.client.interceptors import AfterArgs, BeforeArgs
+from a2a.helpers.proto_helpers import get_message_text
+from a2a.types import (
+    GetTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    TaskState,
+)
 
 
 @dataclass
@@ -27,30 +39,49 @@ class A2AError:
 
 
 class _APIKeyInterceptor(ClientCallInterceptor):
+    """Injects the ``X-API-Key`` header on every outgoing HTTP call.
+
+    The 1.0 SDK feeds ``ClientCallContext.service_parameters`` (a plain
+    ``dict[str, str]``) into the httpx request's ``headers`` kwarg, so we
+    populate that before each call.
+    """
+
     def __init__(self, api_key: str) -> None:
         self._api_key = api_key
 
-    async def intercept(
-        self,
-        method_name: str,
-        request_payload: dict[str, Any],
-        http_kwargs: dict[str, Any],
-        agent_card: AgentCard | None,
-        context: ClientCallContext | None,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        headers = http_kwargs.get("headers", {})
-        headers["X-API-Key"] = self._api_key
-        http_kwargs["headers"] = headers
-        return request_payload, http_kwargs
+    async def before(self, args: BeforeArgs) -> None:
+        if args.context is None:
+            args.context = ClientCallContext()
+        params = args.context.service_parameters
+        if params is None:
+            params = {}
+        params["X-API-Key"] = self._api_key
+        args.context.service_parameters = params
+
+    async def after(self, args: AfterArgs) -> None:
+        return None
 
 
 def _user_message(text: str, context_id: str | None = None) -> Message:
     return Message(
-        messageId=str(uuid4()),
-        role=Role.user,
-        parts=[Part(root=TextPart(text=text))],
-        contextId=context_id,
+        message_id=str(uuid4()),
+        role=Role.ROLE_USER,
+        parts=[Part(text=text)],
+        context_id=context_id or "",
     )
+
+
+_TASK_STATE_NAME = {
+    TaskState.TASK_STATE_WORKING: "working",
+    TaskState.TASK_STATE_COMPLETED: "completed",
+    TaskState.TASK_STATE_FAILED: "failed",
+    TaskState.TASK_STATE_CANCELED: "canceled",
+    TaskState.TASK_STATE_SUBMITTED: "submitted",
+    TaskState.TASK_STATE_INPUT_REQUIRED: "input-required",
+    TaskState.TASK_STATE_REJECTED: "rejected",
+    TaskState.TASK_STATE_AUTH_REQUIRED: "auth-required",
+    TaskState.TASK_STATE_UNSPECIFIED: None,
+}
 
 
 class A2ATestClient:
@@ -61,38 +92,41 @@ class A2ATestClient:
     async def send(
         self, text: str, context_id: str | None = None
     ) -> A2AResponse | A2AError:
-        client = await ClientFactory.connect(
+        client = await create_client(
             agent=self._base_url,
+            client_config=ClientConfig(streaming=False),
             interceptors=[_APIKeyInterceptor(self._api_key)],
         )
 
         msg = _user_message(text, context_id)
-        context_id_out = None
+        context_id_out = context_id
         response_text = ""
         task_id_out = None
         task_state = None
 
-        async for event in client.send_message(msg):
-            if isinstance(event, Message):
-                response_text = get_message_text(event)
-                context_id_out = event.context_id
-                # Message events carry the task_id when the executor sets it
-                # (fast path returns a Message for a completed task).
-                if getattr(event, "task_id", None):
-                    task_id_out = event.task_id
+        request = SendMessageRequest(message=msg)
+        async for event in client.send_message(request):
+            # In 1.0 the client yields ``StreamResponse`` whose ``payload``
+            # oneof is either ``task`` or ``message``.
+            which = event.WhichOneof("payload") if event is not None else None
+            if which == "message":
+                m = event.message
+                response_text = get_message_text(m)
+                if m.context_id:
+                    context_id_out = m.context_id
+                if m.task_id:
+                    task_id_out = m.task_id
                     task_state = "completed"
-            elif isinstance(event, tuple):
-                task, update = event
-                if task:
-                    if task.context_id:
-                        context_id_out = task.context_id
-                    task_id_out = task.id
-                    task_state = task.status.state.value if task.status else None
-                    # If the task is complete, pull the final message out of history.
-                    if task.status and task.status.state.value == "completed":
-                        for m in task.history or []:
-                            if m.role.value == "agent":
-                                response_text = get_message_text(m)
+            elif which == "task":
+                task = event.task
+                if task.context_id:
+                    context_id_out = task.context_id
+                task_id_out = task.id
+                task_state = _TASK_STATE_NAME.get(task.status.state)
+                if task.status.state == TaskState.TASK_STATE_COMPLETED:
+                    for history_msg in task.history:
+                        if history_msg.role == Role.ROLE_AGENT:
+                            response_text = get_message_text(history_msg)
 
         close_fn = getattr(client, "close", None)
         if close_fn is not None:
@@ -106,7 +140,7 @@ class A2ATestClient:
         )
 
     async def get_task(self, task_id: str) -> dict[str, Any]:
-        """Call A2A's ``tasks/get`` to fetch current task state."""
+        """Call A2A's ``tasks/get`` to fetch current task state (0.3 wire format)."""
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid4()),
@@ -116,7 +150,7 @@ class A2ATestClient:
         return await self.send_raw(payload)
 
     async def cancel_task(self, task_id: str) -> dict[str, Any]:
-        """Call A2A's ``tasks/cancel`` to cancel a task."""
+        """Call A2A's ``tasks/cancel`` to cancel a task (0.3 wire format)."""
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid4()),

--- a/tests/integration/test_a2a.py
+++ b/tests/integration/test_a2a.py
@@ -61,3 +61,51 @@ class TestA2AAuth:
                 },
             )
         assert resp.status_code == 401
+
+
+class TestA2ALegacyV0_3Compat:
+    """Verify 0.3 JSON-RPC clients work against the 1.0 mount.
+
+    Exercises the ``enable_v0_3_compat=True`` flag on ``create_jsonrpc_routes``:
+    a client that hand-rolls the legacy 0.3 ``message/send`` method (with
+    0.3-shaped message parts) must still get back a well-formed 0.3 result.
+    """
+
+    @pytest.mark.asyncio
+    async def test_legacy_message_send_returns_0_3_shape(
+        self, server_url: str, api_key: str
+    ) -> None:
+        async with httpx.AsyncClient(timeout=10) as http:
+            resp = await http.post(
+                f"{server_url}/a2a",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "legacy-1",
+                    "method": "message/send",
+                    "params": {
+                        "message": {
+                            "messageId": "legacy-msg-1",
+                            "role": "user",
+                            "parts": [{"kind": "text", "text": "hello"}],
+                        }
+                    },
+                },
+                headers={
+                    "X-API-Key": api_key,
+                    "Content-Type": "application/json",
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # 0.3 response envelope — either a message or a task in ``result``.
+        assert "result" in body, body
+        result = body["result"]
+        # 0.3 parts carry ``kind: "text"`` with the text as a top-level field.
+        if result.get("kind") == "message":
+            parts = result.get("parts", [])
+            assert parts, "expected at least one part"
+            assert parts[0].get("kind") == "text"
+            assert parts[0].get("text")
+        else:
+            assert result.get("kind") == "task"
+            assert result.get("id")

--- a/tests/integration/test_agent_card.py
+++ b/tests/integration/test_agent_card.py
@@ -33,7 +33,10 @@ class TestAgentCard:
             resp = await client.get(f"{server_url}/.well-known/agent-card.json")
         card = resp.json()
         assert "apiKey" in card["securitySchemes"]
-        assert card["security"] == [{"apiKey": []}]
+        # 1.0 renames top-level ``security`` to ``securityRequirements``, with
+        # each entry's scheme map carrying a ``StringList`` value instead of
+        # a bare array. An empty list serializes to ``{}``.
+        assert card["securityRequirements"] == [{"schemes": {"apiKey": {}}}]
 
     @pytest.mark.asyncio
     async def test_legacy_path_still_works(self, server_url: str) -> None:

--- a/tests/unit/test_a2a_task_store.py
+++ b/tests/unit/test_a2a_task_store.py
@@ -31,7 +31,7 @@ class TestTaskStateTranslation:
         a2a_task = task_state_to_a2a_task(state)
         assert a2a_task.id == "t1"
         assert a2a_task.context_id == "c1"
-        assert a2a_task.status.state == A2ATaskState.completed
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_COMPLETED
 
     def test_completed_history_contains_final_response(self) -> None:
         state = TaskState(
@@ -43,9 +43,11 @@ class TestTaskStateTranslation:
         a2a_task = task_state_to_a2a_task(state)
         assert len(a2a_task.history) == 1
         msg = a2a_task.history[0]
-        assert msg.role.value == "agent"
-        # Part is wrapped in Part root.
-        assert msg.parts[0].root.text == "the final answer"
+        # Proto Role uses ROLE_AGENT; value 2 by the enum definition.
+        from a2a.types import Role
+        assert msg.role == Role.ROLE_AGENT
+        # Part carries text directly (no nested TextPart wrapper in 1.0).
+        assert msg.parts[0].text == "the final answer"
 
     def test_working_maps_to_working(self) -> None:
         state = TaskState(
@@ -54,8 +56,8 @@ class TestTaskStateTranslation:
             status=TaskStatus.WORKING,
         )
         a2a_task = task_state_to_a2a_task(state)
-        assert a2a_task.status.state == A2ATaskState.working
-        assert a2a_task.history == []
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_WORKING
+        assert list(a2a_task.history) == []
 
     def test_cancelling_maps_to_working(self) -> None:
         """CANCELLING is an internal state; clients see `working` until terminal."""
@@ -65,7 +67,7 @@ class TestTaskStateTranslation:
             status=TaskStatus.CANCELLING,
         )
         a2a_task = task_state_to_a2a_task(state)
-        assert a2a_task.status.state == A2ATaskState.working
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_WORKING
 
     def test_cancelled_maps_to_canceled(self) -> None:
         state = TaskState(
@@ -75,9 +77,9 @@ class TestTaskStateTranslation:
             error="user requested",
         )
         a2a_task = task_state_to_a2a_task(state)
-        assert a2a_task.status.state == A2ATaskState.canceled
-        assert a2a_task.status.message is not None
-        assert a2a_task.status.message.parts[0].root.text == "user requested"
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_CANCELED
+        assert a2a_task.status.HasField("message")
+        assert a2a_task.status.message.parts[0].text == "user requested"
 
     def test_failed_maps_to_failed(self) -> None:
         state = TaskState(
@@ -87,9 +89,9 @@ class TestTaskStateTranslation:
             error="boom",
         )
         a2a_task = task_state_to_a2a_task(state)
-        assert a2a_task.status.state == A2ATaskState.failed
-        assert a2a_task.status.message is not None
-        assert a2a_task.status.message.parts[0].root.text == "boom"
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_FAILED
+        assert a2a_task.status.HasField("message")
+        assert a2a_task.status.message.parts[0].text == "boom"
 
     def test_empty_content_produces_empty_history(self) -> None:
         state = TaskState(
@@ -99,7 +101,7 @@ class TestTaskStateTranslation:
             content=[],
         )
         a2a_task = task_state_to_a2a_task(state)
-        assert a2a_task.history == []
+        assert list(a2a_task.history) == []
 
 
 # --------------------------------------------------------------------------- #
@@ -132,7 +134,7 @@ class TestEngineTaskStore:
         a2a_task = await task_store.get(state.task_id)
         assert a2a_task is not None
         assert a2a_task.id == state.task_id
-        assert a2a_task.status.state == A2ATaskState.completed
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_COMPLETED
         assert len(a2a_task.history) == 1
 
     @pytest.mark.asyncio
@@ -157,7 +159,7 @@ class TestEngineTaskStore:
 
         a2a_task2 = await task_store.get(state.task_id)
         assert a2a_task2 is not None
-        assert a2a_task2.status.state == A2ATaskState.completed
+        assert a2a_task2.status.state == A2ATaskState.TASK_STATE_COMPLETED
 
     @pytest.mark.asyncio
     async def test_delete_is_noop(
@@ -175,7 +177,6 @@ class TestEngineTaskStore:
     ) -> None:
         """After cancel, GetTask must report the cancelled state."""
         from tests.unit.test_task import ControllableLLM
-        from a2a.types import TaskState as A2ATaskState
         from agentlings.core.llm import LLMResponse
 
         llm = ControllableLLM()
@@ -192,7 +193,7 @@ class TestEngineTaskStore:
         # Before cancel, store reports working.
         a2a_task = await task_store.get(state.task_id)
         assert a2a_task is not None
-        assert a2a_task.status.state == A2ATaskState.working
+        assert a2a_task.status.state == A2ATaskState.TASK_STATE_WORKING
 
         await engine.cancel(state.task_id)
         # Drain LLM so worker wakes at checkpoint.
@@ -207,4 +208,4 @@ class TestEngineTaskStore:
 
         a2a_task2 = await task_store.get(state.task_id)
         assert a2a_task2 is not None
-        assert a2a_task2.status.state == A2ATaskState.canceled
+        assert a2a_task2.status.state == A2ATaskState.TASK_STATE_CANCELED

--- a/tests/unit/test_agent_card.py
+++ b/tests/unit/test_agent_card.py
@@ -10,7 +10,12 @@ def test_generated_card_fields(test_config: AgentConfig) -> None:
     card = generate_agent_card(test_config)
     assert card.name == "test-agent"
     assert card.description == "A test agent"
-    assert card.url == f"http://{test_config.agent_host}:{test_config.agent_port}/a2a"
+    # 1.0 cards expose transport URLs via supported_interfaces; there is no
+    # top-level ``url`` field anymore.
+    urls = [iface.url for iface in card.supported_interfaces]
+    assert (
+        f"http://{test_config.agent_host}:{test_config.agent_port}/a2a" in urls
+    )
 
 
 def test_generated_card_capabilities(test_config: AgentConfig) -> None:
@@ -23,7 +28,10 @@ def test_generated_card_security(test_config: AgentConfig) -> None:
     card = generate_agent_card(test_config)
     assert card.security_schemes is not None
     assert "apiKey" in card.security_schemes
-    assert card.security == [{"apiKey": []}]
+    # security_requirements is a repeated SecurityRequirement; we advertise
+    # a single requirement keying on ``apiKey``.
+    assert len(card.security_requirements) == 1
+    assert "apiKey" in card.security_requirements[0].schemes
 
 
 def test_skills_from_yaml(test_config: AgentConfig) -> None:
@@ -32,7 +40,7 @@ def test_skills_from_yaml(test_config: AgentConfig) -> None:
     assert card.skills[0].id == "testing"
     assert card.skills[0].name == "Testing"
     assert card.skills[0].description == "A test skill"
-    assert card.skills[0].tags == ["test"]
+    assert list(card.skills[0].tags) == ["test"]
 
 
 def test_default_skill_when_no_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
a2a-sdk 1.0 shipped breaking changes (protobuf types, moved mount helper, removed ``new_agent_text_message``) and we need to move off the ``<1.0`` pin landed in #11.

- Bump ``a2a-sdk`` to ``>=1.0.0`` in both the main and dev extras in ``pyproject.toml``.
- Rebuild ``AgentCard``/``AgentCapabilities``/``AgentSkill``/``SecurityScheme`` as protobuf messages. 1.0 drops the top-level ``url`` in favour of ``supported_interfaces`` and renames ``security`` to ``security_requirements`` with ``StringList`` values.
- Translate engine state to proto ``Task``/``Message`` in ``EngineTaskStore`` — ``Part`` carries text directly, enums are fully-qualified (``Role.ROLE_AGENT``, ``TaskState.TASK_STATE_WORKING``). Implement the new abstract ``TaskStore.list`` as an empty ``ListTasksResponse`` since we don't expose a task index.
- Replace ``new_agent_text_message`` (gone in 1.0) with ``a2a.helpers.proto_helpers.new_text_message`` and an explicit ``Role.ROLE_AGENT``.
- Swap the removed ``A2AStarletteApplication`` for ``create_jsonrpc_routes(request_handler, rpc_url, enable_v0_3_compat=True)`` + ``create_agent_card_routes``. Mount the card routes twice so both the 1.0 default (``/.well-known/agent-card.json``) and the legacy 0.3 path (``/.well-known/agent.json``) resolve. ``DefaultRequestHandler`` now requires ``agent_card``; wired through.
- Port the integration A2A client to the 1.0 factory and ``ClientCallInterceptor.before`` — auth headers go through ``ClientCallContext.service_parameters``. Add a wire-level test that sends a 0.3-shaped ``message/send`` request and asserts the 0.3 response envelope, proving ``enable_v0_3_compat=True`` works.

The ``mcp<1.10`` pin is intentionally untouched (tracked in #13).

Closes #12