### PR TITLE
feat: support ollama via anthropic-compatible base url

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ docker run -e ANTHROPIC_API_KEY=... -e AGENT_API_KEY=... -v ./data:/data -p 8420
 ## Configuration
 
 All via environment variables (loaded from `.env` via python-dotenv):
-- `ANTHROPIC_API_KEY` (required)
+- `ANTHROPIC_API_KEY` (required when talking to api.anthropic.com; optional when `ANTHROPIC_BASE_URL` points at a backend that ignores it, e.g. Ollama)
+- `ANTHROPIC_BASE_URL` (optional) — override the Messages endpoint. Set to `http://localhost:11434` to talk to Ollama's Anthropic-compatible API; combine with `AGENT_MODEL` set to an Ollama-served model (e.g. `qwen3-coder`) and `sleep.enabled: false` in the agent YAML since Ollama doesn't implement the batches API
 - `AGENT_API_KEY` (required) — checked via `X-API-Key` header
 - `AGENT_MODEL` (default `claude-sonnet-4-6`)
 - `AGENT_MAX_TOKENS` (default `4096`)

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ Secrets and runtime settings stay in env vars (or `.env` file):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AGENT_CONFIG` | — | Path to agent YAML definition |
-| `ANTHROPIC_API_KEY` | — | Anthropic API key (required for real LLM) |
+| `ANTHROPIC_API_KEY` | — | Anthropic API key (required for api.anthropic.com; optional with `ANTHROPIC_BASE_URL` pointed at e.g. Ollama) |
+| `ANTHROPIC_BASE_URL` | — | Override the Messages endpoint. Use `http://localhost:11434` to target Ollama's Anthropic-compatible API |
 | `AGENT_API_KEY` | — | API key for authenticating clients |
-| `AGENT_MODEL` | `claude-sonnet-4-6` | Anthropic model ID |
+| `AGENT_MODEL` | `claude-sonnet-4-6` | Model ID — set to an Ollama model (e.g. `qwen3-coder`) when using `ANTHROPIC_BASE_URL` |
 | `AGENT_MAX_TOKENS` | `4096` | Max tokens per LLM response |
 | `AGENT_HOST` | `0.0.0.0` | Bind address |
 | `AGENT_PORT` | `8420` | Bind port |

--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -25,6 +25,7 @@ memory:
   # injection_prompt: null  # override the memory injection template
 
 sleep:
+  enabled: true             # set false for backends without batches API (e.g. Ollama)
   schedule: "0 2 * * *"
   journal_retention_days: 30
   conversation_retention_days: 14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ packages = ["src/agentlings"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "ollama: integration tests that require a live Ollama server reachable at OLLAMA_HOST",
+]
 # Silence noisy transitive-dependency deprecations. These are issues in
 # FastAPI/uvicorn/websockets/MCP SDK internals, not our code, and appear on
 # every integration test run. Keep the filter scoped narrowly so our own

--- a/src/agentlings/__main__.py
+++ b/src/agentlings/__main__.py
@@ -100,6 +100,7 @@ def _sleep_command(args: list[str]) -> None:
         api_key=config.anthropic_api_key,
         model=config.agent_model,
         max_tokens=config.agent_max_tokens,
+        base_url=config.anthropic_base_url,
     )
 
     cycle = SleepCycle(

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -31,6 +31,9 @@ class SleepConfig(BaseModel):
     """Nightly sleep cycle configuration.
 
     Attributes:
+        enabled: When ``False``, the sleep cycle is not scheduled even if
+            the block is present. Set this for backends that lack the
+            Anthropic batches API (e.g. Ollama's compatibility layer).
         schedule: Cron expression for when to run (default 2am daily).
         journal_retention_days: How long to keep journal files.
         conversation_retention_days: How long to keep JSONL conversation files.
@@ -40,6 +43,7 @@ class SleepConfig(BaseModel):
         consolidation_prompt: Override for the REM consolidation prompt.
     """
 
+    enabled: bool = True
     schedule: str = "0 2 * * *"
     journal_retention_days: int = 30
     conversation_retention_days: int = 14
@@ -122,6 +126,7 @@ class AgentConfig(BaseSettings):
     )
 
     anthropic_api_key: str = ""
+    anthropic_base_url: str | None = None
     agent_api_key: str = ""
     agent_model: str = "claude-sonnet-4-6"
     agent_max_tokens: int = 4096

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -183,12 +183,29 @@ class BaseLLMClient(ABC):
 
 
 class AnthropicLLMClient(BaseLLMClient):
-    """LLM client backed by the Anthropic Messages API."""
+    """LLM client backed by the Anthropic Messages API.
 
-    def __init__(self, api_key: str, model: str, max_tokens: int) -> None:
+    Also works against any Anthropic-compatible endpoint by passing
+    ``base_url`` — for example Ollama's ``/v1/messages`` compatibility
+    layer at ``http://localhost:11434``. When pointed at such a backend,
+    set the model to one served by that backend (e.g. ``"qwen3-coder"``)
+    and disable features the backend doesn't implement (batches, the
+    sleep cycle, structured output) via configuration.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        max_tokens: int,
+        base_url: str | None = None,
+    ) -> None:
         import anthropic
 
-        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        client_kwargs: dict[str, Any] = {"api_key": api_key or "unset"}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._client = anthropic.AsyncAnthropic(**client_kwargs)
         self._model = model
         self._max_tokens = max_tokens
 
@@ -430,15 +447,20 @@ def create_llm_client(
     model: str = "claude-sonnet-4-6",
     max_tokens: int = 4096,
     tool_names: list[str] | None = None,
+    base_url: str | None = None,
 ) -> BaseLLMClient:
     """Factory that returns the appropriate LLM client for the given backend.
 
     Args:
         backend: Either ``"anthropic"`` for the real API or ``"mock"`` for testing.
-        api_key: Anthropic API key (required for ``"anthropic"`` backend).
+        api_key: Anthropic API key. Required for the upstream Anthropic API,
+            optional when ``base_url`` points at a compatible backend (e.g.
+            Ollama) that does not validate the key.
         model: Model identifier to use for completions.
         max_tokens: Maximum tokens in the model response.
         tool_names: Tool names the mock backend should recognize.
+        base_url: Optional override for the Anthropic Messages endpoint.
+            When set, the client talks to that URL instead of api.anthropic.com.
 
     Returns:
         A configured LLM client instance.
@@ -447,8 +469,13 @@ def create_llm_client(
         logger.info("using mock LLM backend")
         return MockLLMClient(tool_names=tool_names)
 
-    logger.info("using Anthropic LLM backend (model=%s)", model)
-    return AnthropicLLMClient(api_key=api_key, model=model, max_tokens=max_tokens)
+    if base_url:
+        logger.info("using Anthropic-compatible LLM backend (model=%s, base_url=%s)", model, base_url)
+    else:
+        logger.info("using Anthropic LLM backend (model=%s)", model)
+    return AnthropicLLMClient(
+        api_key=api_key, model=model, max_tokens=max_tokens, base_url=base_url,
+    )
 
 
 def _extract_text(message: dict[str, Any]) -> str:

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -102,6 +102,7 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         model=config.agent_model,
         max_tokens=config.agent_max_tokens,
         tool_names=tools.tool_names(),
+        base_url=config.anthropic_base_url,
     )
 
     loop = MessageLoop(
@@ -139,10 +140,12 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         return Response()
 
     sleep_cycle: SleepCycle | None = None
-    if config.sleep_config and memory_store:
+    if config.sleep_config and config.sleep_config.enabled and memory_store:
         sleep_cycle = SleepCycle(
             config=config, llm=llm, memory_store=memory_store, store=store,
         )
+    elif config.sleep_config and not config.sleep_config.enabled:
+        logger.info("sleep cycle disabled by config (sleep.enabled=false)")
 
     @asynccontextmanager
     async def lifespan(app: Starlette) -> AsyncIterator[None]:

--- a/tests/integration/a2a_client.py
+++ b/tests/integration/a2a_client.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
+from a2a.client.client import ClientConfig
 from a2a.client.client_factory import ClientFactory
 from a2a.client.middleware import ClientCallContext, ClientCallInterceptor
 from a2a.types import AgentCard, Message, Part, Role, TextPart
@@ -54,17 +55,30 @@ def _user_message(text: str, context_id: str | None = None) -> Message:
 
 
 class A2ATestClient:
-    def __init__(self, base_url: str, api_key: str) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        request_timeout: float | None = None,
+    ) -> None:
         self._base_url = base_url
         self._api_key = api_key
+        self._request_timeout = request_timeout
 
     async def send(
         self, text: str, context_id: str | None = None
     ) -> A2AResponse | A2AError:
-        client = await ClientFactory.connect(
-            agent=self._base_url,
-            interceptors=[_APIKeyInterceptor(self._api_key)],
-        )
+        connect_kwargs: dict[str, Any] = {
+            "agent": self._base_url,
+            "interceptors": [_APIKeyInterceptor(self._api_key)],
+        }
+        if self._request_timeout is not None:
+            httpx_client = httpx.AsyncClient(timeout=self._request_timeout)
+            connect_kwargs["client_config"] = ClientConfig(
+                streaming=False, httpx_client=httpx_client,
+            )
+            connect_kwargs["resolver_http_kwargs"] = {"timeout": self._request_timeout}
+        client = await ClientFactory.connect(**connect_kwargs)
 
         msg = _user_message(text, context_id)
         context_id_out = None

--- a/tests/integration/test_ollama.py
+++ b/tests/integration/test_ollama.py
@@ -1,0 +1,288 @@
+"""Live integration tests against a real Ollama server.
+
+These tests require an Ollama instance reachable on the network with the
+models ``qwen3:4b`` and ``gemma3:4b`` already pulled. They are gated
+behind the ``ollama`` pytest marker and the ``OLLAMA_HOST`` environment
+variable so they don't run as part of the default CI loop.
+
+Defaults assume the dev cluster at ``192.168.69.21:11434``. Override
+with ``OLLAMA_HOST=http://host:port pytest -m ollama``.
+
+Run with:
+
+    pytest -m ollama tests/integration/test_ollama.py
+
+Skip with:
+
+    pytest -m "not ollama"  # the default in most CI configurations
+
+Test layout:
+
+* ``TestOllamaLLMClient`` — drives ``AnthropicLLMClient`` directly against
+  Ollama. Proves the ``base_url`` override reaches the right host and
+  that prompts come back through the Anthropic-shaped content-block
+  parser. This is the contract Ollama compatibility actually has to hold.
+* ``TestOllamaA2A`` — boots a real agentling pointed at Ollama and sends
+  one A2A message per model. Smaller smoke test — no tools (``gemma3:4b``
+  rejects requests with a ``tools`` array) and no memory-recall asserts
+  (4B-class models are too unreliable for that within fast-path timeouts).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
+
+from agentlings.config import AgentConfig
+from agentlings.core.llm import AnthropicLLMClient
+from agentlings.server import _create_app
+from tests.integration.a2a_client import A2AResponse, A2ATestClient
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://192.168.69.21:11434")
+OLLAMA_MODELS = ["qwen3:4b", "gemma3:4b"]
+
+
+def _ollama_reachable(url: str, timeout: float = 2.0) -> bool:
+    try:
+        resp = httpx.get(f"{url}/api/tags", timeout=timeout)
+        return resp.status_code == 200
+    except (httpx.HTTPError, OSError):
+        return False
+
+
+pytestmark = [
+    pytest.mark.ollama,
+    pytest.mark.skipif(
+        not _ollama_reachable(OLLAMA_HOST),
+        reason=f"Ollama not reachable at {OLLAMA_HOST}",
+    ),
+]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# --------------------------------------------------------------------------- #
+# Direct LLM client tests — exercise the AnthropicLLMClient against Ollama
+# without the full A2A/MCP stack. These are the contract tests for the
+# ``base_url`` override added for Ollama support.
+# --------------------------------------------------------------------------- #
+
+
+class TestOllamaLLMClient:
+    @pytest.mark.parametrize("model", OLLAMA_MODELS)
+    async def test_completion_reaches_ollama(self, model: str) -> None:
+        """``AnthropicLLMClient`` with ``base_url`` should hit the Ollama endpoint
+        and return a non-empty text content block.
+
+        The prompt asks for the literal token ``OLLAMA-OK`` so we have a
+        concrete signal that the pipeline carried text both ways.
+        """
+        client = AnthropicLLMClient(
+            api_key="ollama",
+            model=model,
+            max_tokens=256,
+            base_url=OLLAMA_HOST,
+        )
+        response = await client.complete(
+            system=[{"type": "text", "text": "Reply concisely."}],
+            messages=[{
+                "role": "user",
+                "content": "Reply with exactly the token OLLAMA-OK and nothing else.",
+            }],
+            tools=[],
+        )
+
+        assert response.content, f"{model}: empty content list"
+        assert response.stop_reason, f"{model}: missing stop_reason"
+
+        text_blocks = [b for b in response.content if b.get("type") == "text"]
+        assert text_blocks, f"{model}: no text content blocks in {response.content!r}"
+        joined = " ".join(b.get("text", "") for b in text_blocks)
+        assert joined.strip(), f"{model}: text blocks were empty"
+
+    async def test_qwen_supports_tools(self) -> None:
+        """qwen3:4b is the tool-capable model on this Ollama box.
+
+        We pass an Anthropic-shaped tool schema and assert the Ollama
+        endpoint accepts the request (i.e. doesn't 400 with
+        ``model does not support tools`` the way gemma3:4b does). We
+        intentionally don't assert the model *invokes* the tool — small
+        models are inconsistent and that's a model behaviour test, not a
+        compatibility test.
+        """
+        client = AnthropicLLMClient(
+            api_key="ollama",
+            model="qwen3:4b",
+            max_tokens=256,
+            base_url=OLLAMA_HOST,
+        )
+        response = await client.complete(
+            system=[{"type": "text", "text": "You may use the echo tool."}],
+            messages=[{
+                "role": "user",
+                "content": "Please call the echo tool with text='hi'.",
+            }],
+            tools=[{
+                "name": "echo",
+                "description": "Echo back the supplied text.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }],
+        )
+        assert response.content, "qwen3:4b returned no content with tools attached"
+
+    async def test_gemma_rejects_tools(self) -> None:
+        """gemma3:4b on Ollama rejects requests that include a tool schema.
+
+        This locks in the operational contract: an agentling configured
+        with tools cannot be backed by gemma3:4b. If Ollama later starts
+        supporting tools for gemma, this test will start failing — at
+        which point we can flip gemma into the tool-capable list above.
+        """
+        client = AnthropicLLMClient(
+            api_key="ollama",
+            model="gemma3:4b",
+            max_tokens=128,
+            base_url=OLLAMA_HOST,
+        )
+        with pytest.raises(Exception) as exc_info:
+            await client.complete(
+                system=[{"type": "text", "text": "hi"}],
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[{
+                    "name": "echo",
+                    "description": "echo",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                    },
+                }],
+            )
+        assert "does not support tools" in str(exc_info.value).lower() or \
+               "400" in str(exc_info.value), \
+               f"Expected gemma3:4b tool rejection, got: {exc_info.value!r}"
+
+    async def test_completion_without_tools_works_for_gemma(self) -> None:
+        """Same gemma3:4b request as above but without a tools array — should succeed."""
+        client = AnthropicLLMClient(
+            api_key="ollama",
+            model="gemma3:4b",
+            max_tokens=128,
+            base_url=OLLAMA_HOST,
+        )
+        response = await client.complete(
+            system=[{"type": "text", "text": "Reply concisely."}],
+            messages=[{"role": "user", "content": "Say hi in one word."}],
+            tools=[],
+        )
+        text_blocks = [b for b in response.content if b.get("type") == "text"]
+        assert text_blocks, f"gemma3:4b returned no text without tools: {response.content!r}"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end A2A smoke test — boots a real agentling pointed at Ollama and
+# round-trips a single message. No tools (gemma rejects them, qwen handles
+# them flakily on a 4B model). Proves the server lifespan, A2A executor,
+# task engine, and Anthropic-compatible client all wire up correctly.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module", params=OLLAMA_MODELS, ids=lambda m: m.replace(":", "_"))
+def ollama_agentling(request, tmp_path_factory):
+    model = request.param
+    api_key = "ollama-integration-test-key"
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+
+    safe = model.replace(":", "_").replace("/", "_")
+    data_dir = tmp_path_factory.mktemp(f"data_{safe}")
+    agent_yaml = tmp_path_factory.mktemp(f"config_{safe}") / "agent.yaml"
+    # No tools: gemma3:4b rejects any request with a tools array, and we
+    # don't need tool execution to verify Anthropic-compatibility plumbing.
+    agent_yaml.write_text(
+        "name: ollama-test-agent\n"
+        "description: Integration test agent backed by Ollama\n"
+        "tools: []\n"
+        "sleep:\n"
+        "  enabled: false\n"
+    )
+
+    config = AgentConfig(
+        anthropic_api_key="ollama",
+        anthropic_base_url=OLLAMA_HOST,
+        agent_api_key=api_key,
+        agent_data_dir=data_dir,
+        agent_llm_backend="anthropic",
+        agent_model=model,
+        # qwen3 is a thinking model that emits <think> blocks before its
+        # final answer — a small max_tokens cap truncates the assistant
+        # before any user-visible text is produced.
+        agent_max_tokens=2048,
+        agent_host="127.0.0.1",
+        agent_port=port,
+        agent_config=str(agent_yaml),
+        agent_task_await_seconds=120,
+    )
+    app = _create_app(config)
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    )
+    loop = asyncio.new_event_loop()
+
+    def _run() -> None:
+        loop.run_until_complete(server.serve())
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    for _ in range(50):
+        try:
+            resp = httpx.get(f"{url}/.well-known/agent-card.json")
+            if resp.status_code == 200:
+                break
+        except httpx.ConnectError:
+            time.sleep(0.1)
+    else:
+        server.should_exit = True
+        thread.join(timeout=5)
+        raise RuntimeError(f"agentling failed to start for model {model}")
+
+    yield url, api_key, model
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+class TestOllamaA2A:
+    async def test_round_trip(self, ollama_agentling) -> None:
+        """A user message in, an assistant text response out — through Ollama.
+
+        Asserts on shape (non-empty text, present context_id), not content.
+        Small open-source models are too unpredictable for content asserts
+        and that's not what this test exists to check.
+        """
+        url, api_key, model = ollama_agentling
+        # 4B-class models on Ollama can take 30s+ on cold-load — bump the
+        # client-side httpx timeout well past the SDK's default.
+        client = A2ATestClient(url, api_key, request_timeout=180.0)
+        result = await client.send("Say hi in one short sentence.")
+        assert isinstance(result, A2AResponse), f"{model}: {result!r}"
+        assert result.context_id, f"{model}: missing context_id"
+        assert result.text.strip(), (
+            f"{model}: empty assistant response — task likely returned a "
+            f"slow-path handle. Raw: {result.raw!r}"
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,6 +29,21 @@ def test_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.agent_port == 8420
     assert config.agent_log_level == "INFO"
     assert config.agent_llm_backend == "anthropic"
+    assert config.anthropic_base_url is None
+
+
+def test_anthropic_base_url_from_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pointing at Ollama is via env, mirroring how operators actually set it."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://192.168.69.21:11434")
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        _env_file=None,
+    )
+    assert config.anthropic_base_url == "http://192.168.69.21:11434"
 
 
 def test_default_agent_identity(tmp_path: Path) -> None:
@@ -216,6 +231,7 @@ class TestMemoryConfig:
 class TestSleepConfig:
     def test_defaults(self) -> None:
         config = SleepConfig()
+        assert config.enabled is True
         assert config.schedule == "0 2 * * *"
         assert config.journal_retention_days == 30
         assert config.conversation_retention_days == 14
@@ -223,6 +239,28 @@ class TestSleepConfig:
         assert config.model is None
         assert config.summary_prompt is None
         assert config.consolidation_prompt is None
+
+    def test_disabled_flag_parses(self) -> None:
+        """Backends without the batches API (e.g. Ollama) flip this to false."""
+        config = SleepConfig(enabled=False)
+        assert config.enabled is False
+
+    def test_disabled_from_yaml(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "agent.yaml"
+        yaml_file.write_text(
+            "name: test\n"
+            "description: test\n"
+            "sleep:\n"
+            "  enabled: false\n"
+        )
+        config = AgentConfig(
+            anthropic_api_key="sk-test",
+            agent_api_key="key",
+            agent_data_dir=tmp_path / "data",
+            agent_config=str(yaml_file),
+        )
+        assert config.sleep_config is not None
+        assert config.sleep_config.enabled is False
 
 
 class TestTelemetryConfig:

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -123,6 +123,38 @@ class TestFactory:
         client = create_llm_client(backend="anthropic", api_key="sk-test")
         assert isinstance(client, AnthropicLLMClient)
 
+    def test_anthropic_backend_with_base_url(self) -> None:
+        """``base_url`` reaches the underlying Anthropic SDK client.
+
+        This is the core wiring for Ollama compatibility — if it regresses,
+        every Ollama request silently goes back to api.anthropic.com.
+        """
+        from agentlings.core.llm import AnthropicLLMClient
+
+        client = create_llm_client(
+            backend="anthropic",
+            api_key="ollama",
+            model="qwen3:4b",
+            base_url="http://localhost:11434",
+        )
+        assert isinstance(client, AnthropicLLMClient)
+        assert str(client._client.base_url).rstrip("/") == "http://localhost:11434"
+
+    def test_anthropic_backend_empty_api_key_with_base_url(self) -> None:
+        """An empty api_key + base_url should fall back to a placeholder so
+        the Anthropic SDK doesn't refuse to construct. Backends that ignore
+        the header (Ollama) accept this happily.
+        """
+        from agentlings.core.llm import AnthropicLLMClient
+
+        client = AnthropicLLMClient(
+            api_key="",
+            model="qwen3:4b",
+            max_tokens=128,
+            base_url="http://localhost:11434",
+        )
+        assert client._client.api_key == "unset"
+
 
 class TestMockLLMDelay:
     """``delay-N`` markers in user messages produce genuine async sleeps."""


### PR DESCRIPTION
Ollama v0.14+ exposes the Anthropic Messages API on `/v1/messages`, so an agentling can be backed by Ollama with no new client — but only if we let operators point at it and skip the parts Ollama doesn't implement.

- `ANTHROPIC_BASE_URL` env var routes the existing `AnthropicLLMClient` at any compatible endpoint (`http://host:11434`); model name is the existing `AGENT_MODEL`
- `sleep.enabled` YAML flag (default `true`) lets operators disable the nightly sleep cycle on backends without the batches API; flipping it to `false` short-circuits `SleepCycle` construction in `server.py`
- `AnthropicLLMClient` falls back to a placeholder api key when blank + `base_url` is set, since Ollama accepts but doesn't validate the header
- Live Ollama integration tests against `qwen3:4b` and `gemma3:4b`, gated behind a new `ollama` pytest marker and the `OLLAMA_HOST` env var so default CI is unaffected
- `gemma3:4b` rejects requests with a `tools` array — that's pinned as a contract test so it'll start failing if Ollama later adds gemma tool support
- `A2ATestClient` gains an optional `request_timeout` to accommodate cold-load latency on small open-source models
- Unit coverage for `SleepConfig.enabled`, `ANTHROPIC_BASE_URL` env-var plumbing, and the LLM-client base-url forwarding