### PR TITLE
fix: populate task.artifacts on completion per a2a spec

### DIFF
--- a/src/agentlings/protocol/a2a_task_store.py
+++ b/src/agentlings/protocol/a2a_task_store.py
@@ -18,6 +18,7 @@ from typing import Any
 from a2a.server.context import ServerCallContext
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import (
+    Artifact,
     ListTasksRequest,
     ListTasksResponse,
     Message,
@@ -50,11 +51,12 @@ _STATE_MAP: dict[TaskStatus, int] = {
 def task_state_to_a2a_task(state: TaskState) -> Task:
     """Render an engine ``TaskState`` as an A2A ``Task`` for the wire.
 
-    Completed tasks carry their final assistant message in ``history`` so
-    ``GetTask`` responses are self-contained — the client doesn't need a
-    separate call to retrieve the result.
+    Completed tasks carry their final assistant message in both ``artifacts``
+    (per the A2A spec, which says results SHOULD be returned via Artifacts)
+    and ``history`` (kept for backward compatibility with existing clients).
     """
     history: list[Message] = []
+    artifacts: list[Artifact] = []
     if state.status == TaskStatus.COMPLETED and state.content:
         text = _extract_text(state.content)
         if text:
@@ -65,6 +67,12 @@ def task_state_to_a2a_task(state: TaskState) -> Task:
                     context_id=state.context_id,
                     task_id=state.task_id,
                     message_id=f"{state.task_id}-final",
+                )
+            )
+            artifacts.append(
+                Artifact(
+                    artifact_id=f"{state.task_id}-result",
+                    parts=[Part(text=text)],
                 )
             )
 
@@ -82,6 +90,7 @@ def task_state_to_a2a_task(state: TaskState) -> Task:
         id=state.task_id,
         context_id=state.context_id,
         status=A2ATaskStatus(**status_kwargs),
+        artifacts=artifacts,
         history=history,
     )
 

--- a/tests/unit/test_a2a_task_store.py
+++ b/tests/unit/test_a2a_task_store.py
@@ -49,6 +49,22 @@ class TestTaskStateTranslation:
         # Part carries text directly (no nested TextPart wrapper in 1.0).
         assert msg.parts[0].text == "the final answer"
 
+    def test_completed_artifacts_contain_final_response(self) -> None:
+        """A2A spec: results SHOULD be returned via Artifacts on the Task."""
+        state = TaskState(
+            task_id="t1",
+            context_id="c1",
+            status=TaskStatus.COMPLETED,
+            content=[{"type": "text", "text": "the final answer"}],
+        )
+        a2a_task = task_state_to_a2a_task(state)
+        assert len(a2a_task.artifacts) == 1
+        artifact = a2a_task.artifacts[0]
+        assert artifact.artifact_id == "t1-result"
+        assert artifact.parts[0].text == "the final answer"
+        # History remains populated for backward compatibility.
+        assert len(a2a_task.history) == 1
+
     def test_working_maps_to_working(self) -> None:
         state = TaskState(
             task_id="t1",


### PR DESCRIPTION
A2A spec says task results SHOULD be returned via Artifacts on the Task. Today `task_state_to_a2a_task` only populates `task.history`, so spec-compliant clients reading `task.artifacts` on `tasks/get` get nothing.

- Build an `Artifact` carrying the final assistant text on `COMPLETED` state, alongside the existing `history` Message
- Keep `history` populated for backward compatibility with existing clients reading the agent reply from there
- MCP path untouched — it consumes engine `TaskState` directly and never goes through `task_state_to_a2a_task`

Known follow-ups not in this PR:
- `task.history` only carries the agent reply; the originating user message is never appended
- When non-text content (image parts) lands, `_extract_text` will need widening — artifact would be empty otherwise