### PR TITLE
chore: release 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.2.1"
+version = "0.2.2"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Ships the A2A artifact spec-compliance fix from #19 — `task.artifacts` is now populated on completion alongside the existing `history`.

Tag `v0.2.2` after merge to trigger the PyPI publish workflow.