### PR TITLE
chore: release 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.2.2"
+version = "0.2.3"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Ships #21 — A2A executor now honors `configuration.return_immediately` on `message/send`, letting clients request a `Task` handle without burning the `AGENT_TASK_AWAIT_SECONDS` window.