### PR TITLE
feat: @tool decorator and AGENT_TOOLS_DIR folder scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.2.3"
+version = "0.2.4"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -162,6 +162,7 @@ class AgentConfig(BaseSettings):
     agent_otel_insecure: bool = True
     agent_otel_headers: str = ""
     agent_task_await_seconds: int = 60
+    agent_tools_dir: Path | None = None
 
     _definition: AgentDefinition = AgentDefinition()
 

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -32,6 +32,7 @@ from agentlings.protocol.a2a import AgentlingExecutor
 from agentlings.protocol.a2a_task_store import EngineTaskStore
 from agentlings.protocol.agent_card import generate_agent_card
 from agentlings.protocol.mcp import create_mcp_server
+from agentlings.tools.loader import load_tools_from_directory
 from agentlings.tools.memory import init_memory_tool
 from agentlings.tools.registry import ToolRegistry
 
@@ -90,6 +91,9 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
 
     tools = ToolRegistry()
     tools.register_tools(config.enabled_tools, bash_timeout=config.definition.bash_timeout)
+
+    if config.agent_tools_dir is not None:
+        load_tools_from_directory(config.agent_tools_dir, tools)
 
     if not tools.tool_names():
         logger.warning(

--- a/src/agentlings/tools/__init__.py
+++ b/src/agentlings/tools/__init__.py
@@ -1,1 +1,10 @@
 """Pluggable tool system with built-in bash and filesystem implementations."""
+
+from agentlings.tools.decorator import (
+    Tool,
+    ToolDefinitionError,
+    ToolInputError,
+    tool,
+)
+
+__all__ = ["Tool", "ToolDefinitionError", "ToolInputError", "tool"]

--- a/src/agentlings/tools/decorator.py
+++ b/src/agentlings/tools/decorator.py
@@ -1,0 +1,218 @@
+"""``@tool`` decorator: turn a typed Python function into a self-describing tool.
+
+A tool is a self-contained unit. The decorator infers everything the LLM needs
+from the function itself:
+
+- ``name``         from ``func.__name__`` (or override).
+- ``description``  from the docstring (or override).
+- ``input_schema`` derived from the parameter type annotations using Pydantic.
+
+Per-parameter descriptions and constraints attach via
+``Annotated[T, Field(description="...", ge=..., le=...)]`` — the idiomatic
+Python way and the single source of truth (no separate docstring parser).
+
+Sync and async functions are both supported; the resulting ``Tool`` exposes a
+unified ``async call(args)`` regardless.
+
+Output: ``tool.to_anthropic_dict()`` returns ``{name, description,
+input_schema}`` — exactly the shape the agent registry already passes to
+``messages.create(tools=...)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from inspect import Parameter
+from typing import Any, Awaitable, Callable, Generic, TypeVar, get_type_hints, overload
+
+from pydantic import BaseModel, ValidationError, create_model
+
+R = TypeVar("R")
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class ToolDefinitionError(TypeError):
+    """Raised when a function cannot be turned into a tool.
+
+    Common causes: missing type annotations, ``*args``/``**kwargs``, or
+    positional-only parameters.
+    """
+
+
+class ToolInputError(ValueError):
+    """Raised when ``Tool.call`` receives arguments that fail schema validation.
+
+    Carries the underlying ``pydantic.ValidationError`` for callers that want
+    structured error reporting; ``str(e)`` is a human-readable summary.
+    """
+
+    def __init__(self, message: str, *, validation_error: ValidationError) -> None:
+        super().__init__(message)
+        self.validation_error = validation_error
+
+
+class Tool(Generic[R]):
+    """A typed, self-describing callable the agent can expose to the LLM.
+
+    Attributes:
+        func: The underlying user function.
+        name: The identifier the LLM uses to invoke the tool.
+        description: Human-readable description for the LLM.
+        input_schema: JSON Schema describing the tool's input parameters.
+        is_async: ``True`` when ``func`` is a coroutine function.
+    """
+
+    func: Callable[..., Any]
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    is_async: bool
+
+    def __init__(
+        self,
+        func: Callable[..., R] | Callable[..., Awaitable[R]],
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        self.func = func
+        self.is_async = asyncio.iscoroutinefunction(func)
+        self.name = name or func.__name__
+
+        if description is not None:
+            self.description = description
+        elif func.__doc__:
+            self.description = inspect.cleandoc(func.__doc__)
+        else:
+            self.description = ""
+
+        self._input_model = _build_input_model(func)
+        self.input_schema = _clean_schema(
+            self._input_model.model_json_schema(),
+        )
+
+    async def call(self, args: dict[str, Any]) -> R:
+        """Validate ``args`` against the schema and invoke the tool.
+
+        Sync functions run on a worker thread so an async caller never blocks.
+        """
+        try:
+            validated = self._input_model.model_validate(args)
+        except ValidationError as e:
+            raise ToolInputError(
+                f"Invalid arguments for tool {self.name!r}: {e.error_count()} "
+                f"validation error(s).",
+                validation_error=e,
+            ) from e
+
+        kwargs = {k: getattr(validated, k) for k in self._input_model.model_fields}
+        if self.is_async:
+            return await self.func(**kwargs)  # type: ignore[no-any-return]
+        return await asyncio.to_thread(self.func, **kwargs)
+
+    def to_anthropic_dict(self) -> dict[str, Any]:
+        """Render the tool in the shape ``messages.create(tools=...)`` expects."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        kind = "async" if self.is_async else "sync"
+        return f"<Tool {self.name!r} ({kind})>"
+
+
+@overload
+def tool(func: F) -> Tool[Any]: ...
+
+
+@overload
+def tool(
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> Callable[[F], Tool[Any]]: ...
+
+
+def tool(
+    func: Callable[..., Any] | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> Tool[Any] | Callable[[Callable[..., Any]], Tool[Any]]:
+    """Wrap a function as a ``Tool``.
+
+    Usable bare or with overrides::
+
+        @tool
+        async def fetch(url: str) -> str:
+            ...
+
+        @tool(name="custom", description="…")
+        def other(...): ...
+    """
+
+    def _make(fn: Callable[..., Any]) -> Tool[Any]:
+        return Tool(fn, name=name, description=description)
+
+    if func is not None:
+        return _make(func)
+    return _make
+
+
+def _build_input_model(func: Callable[..., Any]) -> type[BaseModel]:
+    """Build a Pydantic model representing the function's keyword arguments.
+
+    Uses ``get_type_hints(..., include_extras=True)`` so ``Annotated`` metadata
+    (``pydantic.Field(...)``) is preserved and feeds ``model_json_schema``.
+    """
+    sig = inspect.signature(func)
+    try:
+        type_hints = get_type_hints(func, include_extras=True)
+    except NameError as e:
+        raise ToolDefinitionError(
+            f"Tool {func.__name__!r}: could not resolve type hints ({e}). "
+            f"Use ``from __future__ import annotations`` and ensure all referenced "
+            f"types are importable from the function's module."
+        ) from e
+
+    fields: dict[str, Any] = {}
+    for param_name, param in sig.parameters.items():
+        if param.kind == Parameter.VAR_POSITIONAL:
+            raise ToolDefinitionError(
+                f"Tool {func.__name__!r}: ``*{param_name}`` is not supported."
+            )
+        if param.kind == Parameter.VAR_KEYWORD:
+            raise ToolDefinitionError(
+                f"Tool {func.__name__!r}: ``**{param_name}`` is not supported."
+            )
+        if param.kind == Parameter.POSITIONAL_ONLY:
+            raise ToolDefinitionError(
+                f"Tool {func.__name__!r}: positional-only parameter "
+                f"{param_name!r} is not supported."
+            )
+        if param_name not in type_hints:
+            raise ToolDefinitionError(
+                f"Tool {func.__name__!r}: parameter {param_name!r} must have a "
+                f"type annotation."
+            )
+
+        annotation = type_hints[param_name]
+        default: Any = param.default if param.default is not Parameter.empty else ...
+        fields[param_name] = (annotation, default)
+
+    return create_model(f"{func.__name__}__InputSchema", **fields)
+
+
+def _clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Drop Pydantic's noisy top-level ``title`` field; keep everything else.
+
+    The top-level ``title`` is a Pydantic auto-generated identifier (e.g.
+    ``foo__InputSchema``) that clutters the LLM-facing schema. Nested ``title``
+    fields are left alone — Pydantic generates them for enum classes and
+    sub-models where they may carry meaning.
+    """
+    schema.pop("title", None)
+    return schema

--- a/src/agentlings/tools/examples/__init__.py
+++ b/src/agentlings/tools/examples/__init__.py
@@ -1,0 +1,22 @@
+"""Reference tools demonstrating the ``@tool`` decorator surface.
+
+These are intentionally small and illustrative — they exist to show
+authors how to express common patterns:
+
+- ``echo``    — simplest possible tool, no I/O.
+- ``http_get``— async I/O + ``Annotated[..., Field(...)]`` per-param descriptions.
+- ``set_severity`` — string ``Enum`` parameter.
+- ``geocode`` — env-var-driven config + nested ``BaseModel`` parameter.
+
+They are not registered by default; agent configs opt in by name once the
+loader supports plugin discovery.
+"""
+
+from agentlings.tools.examples.echo import echo
+from agentlings.tools.examples.geocode import geocode
+from agentlings.tools.examples.http_get import http_get
+from agentlings.tools.examples.set_severity import set_severity
+
+EXAMPLE_TOOLS = [echo, http_get, set_severity, geocode]
+
+__all__ = ["EXAMPLE_TOOLS", "echo", "geocode", "http_get", "set_severity"]

--- a/src/agentlings/tools/examples/echo.py
+++ b/src/agentlings/tools/examples/echo.py
@@ -1,0 +1,14 @@
+"""Smallest possible tool — echoes its input back."""
+
+from __future__ import annotations
+
+from agentlings.tools import tool
+
+
+@tool
+def echo(message: str) -> str:
+    """Echo a message back unchanged.
+
+    Useful for sanity-checking that the tool plumbing is working end-to-end.
+    """
+    return message

--- a/src/agentlings/tools/examples/geocode.py
+++ b/src/agentlings/tools/examples/geocode.py
@@ -1,0 +1,57 @@
+"""Env-var-driven config + nested ``BaseModel`` parameter.
+
+Demonstrates the recommended pattern for tools that need credentials or
+endpoint config: read them from the process environment inside the tool —
+the framework stays out of secret plumbing entirely.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Annotated
+
+import httpx
+from pydantic import BaseModel, Field
+
+from agentlings.tools import tool
+
+
+class Address(BaseModel):
+    """A postal address. Only the fields the geocoder needs are required."""
+
+    street: str
+    city: str
+    country: Annotated[str, Field(description="ISO 3166-1 alpha-2 country code, e.g. 'IE'.")]
+
+
+class Coordinates(BaseModel):
+    lat: float
+    lng: float
+
+
+@tool
+async def geocode(address: Address) -> Coordinates:
+    """Resolve a postal address to latitude/longitude.
+
+    Reads ``GEOCODE_API_KEY`` from the environment. Tools own their own
+    secret plumbing; the framework is intentionally not involved.
+    """
+    api_key = os.environ.get("GEOCODE_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "GEOCODE_API_KEY is not set. Configure the tool's environment "
+            "before enabling it on an agent."
+        )
+
+    base_url = os.environ.get("GEOCODE_BASE_URL", "https://api.example.com/geocode")
+    params = {
+        "street": address.street,
+        "city": address.city,
+        "country": address.country,
+        "key": api_key,
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(base_url, params=params)
+        response.raise_for_status()
+        payload = response.json()
+        return Coordinates(lat=payload["lat"], lng=payload["lng"])

--- a/src/agentlings/tools/examples/http_get.py
+++ b/src/agentlings/tools/examples/http_get.py
@@ -1,0 +1,29 @@
+"""Async I/O tool with ``Annotated[..., Field(...)]`` parameter descriptions."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import httpx
+from pydantic import Field
+
+from agentlings.tools import tool
+
+
+@tool
+async def http_get(
+    url: Annotated[str, Field(description="Absolute URL to fetch (must be http/https).")],
+    timeout_seconds: Annotated[
+        float,
+        Field(ge=1.0, le=60.0, description="Per-request timeout in seconds."),
+    ] = 10.0,
+) -> str:
+    """Fetch a URL via HTTP GET and return the response body as text.
+
+    The tool follows redirects and raises if the response status is >= 400 so
+    the LLM sees a clear failure signal rather than a misleading empty body.
+    """
+    async with httpx.AsyncClient(follow_redirects=True, timeout=timeout_seconds) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text

--- a/src/agentlings/tools/examples/set_severity.py
+++ b/src/agentlings/tools/examples/set_severity.py
@@ -1,0 +1,25 @@
+"""String ``Enum`` parameter — the LLM sees a constrained set of values."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from agentlings.tools import tool
+
+
+class Severity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@tool
+def set_severity(severity: Severity, reason: str) -> str:
+    """Record an incident's severity level.
+
+    The model picks one of the enum values; the framework validates the input
+    before the function is invoked, so the function body can rely on
+    ``severity`` being a valid ``Severity``.
+    """
+    return f"severity={severity.value} reason={reason}"

--- a/src/agentlings/tools/loader.py
+++ b/src/agentlings/tools/loader.py
@@ -1,0 +1,126 @@
+"""Folder-scan loader for ``@tool``-decorated user tools.
+
+Discovery contract:
+
+- The framework scans ``AGENT_TOOLS_DIR`` (a directory) for ``*.py`` files.
+- Each file is imported as an isolated module under the synthetic package
+  ``agentling_user_tools.<filename_stem>``; the directory is *not* added to
+  ``sys.path`` so user tools cannot accidentally shadow installed packages.
+- Files whose name begins with ``_`` are skipped (private/helpers).
+- Every module-level attribute that is a ``Tool`` instance is registered
+  with the supplied ``ToolRegistry``.
+- Import failures and registration failures are logged and skipped — one
+  broken tool must not crash the agent.
+
+The loader is intentionally permissive about *what* a user file contains:
+it only registers ``Tool`` instances and ignores everything else, so a file
+can define helpers, classes, env-var reads, or whatever the tool author
+needs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agentlings.tools.decorator import Tool
+
+if TYPE_CHECKING:
+    from agentlings.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+_USER_TOOLS_PACKAGE = "agentling_user_tools"
+
+
+def load_tools_from_directory(
+    directory: Path,
+    registry: "ToolRegistry",
+) -> list[str]:
+    """Scan ``directory`` and register every ``Tool`` instance found.
+
+    Args:
+        directory: Filesystem path to scan. ``.py`` files at the top level
+            are imported (no recursion, no sub-packages).
+        registry: The ``ToolRegistry`` to register discovered tools into.
+
+    Returns:
+        The names of tools that were successfully registered. The list is in
+        directory-walk order, which the caller may sort if it wants stable
+        output.
+
+    The function never raises for content issues: missing directory, broken
+    imports, and registration failures are logged and the scan continues. It
+    only raises for argument-shape problems (wrong types passed in).
+    """
+    if not directory.exists():
+        logger.info(
+            "tool directory %s does not exist — skipping scan", directory
+        )
+        return []
+    if not directory.is_dir():
+        logger.warning(
+            "AGENT_TOOLS_DIR=%s is not a directory — skipping scan", directory
+        )
+        return []
+
+    registered: list[str] = []
+    for path in sorted(directory.iterdir()):
+        if not path.is_file():
+            continue
+        if path.suffix != ".py":
+            continue
+        if path.stem.startswith("_"):
+            logger.debug("skipping private tool file: %s", path)
+            continue
+
+        module_name = f"{_USER_TOOLS_PACKAGE}.{path.stem}"
+        try:
+            module = _import_isolated_module(module_name, path)
+        except Exception:  # noqa: BLE001 — log and continue to next file
+            logger.exception("failed to import tool file %s", path)
+            continue
+
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if not isinstance(attr, Tool):
+                continue
+            try:
+                registry.register_tool_object(attr)
+                registered.append(attr.name)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "failed to register tool %r from %s", attr.name, path
+                )
+
+    if registered:
+        logger.info(
+            "loaded %d user tool(s) from %s: %s",
+            len(registered),
+            directory,
+            sorted(registered),
+        )
+    else:
+        logger.info("no user tools registered from %s", directory)
+
+    return registered
+
+
+def _import_isolated_module(module_name: str, path: Path) -> object:
+    """Import a single file as ``module_name`` without polluting ``sys.path``.
+
+    Uses ``importlib.util.spec_from_file_location`` so the file is imported
+    by absolute path; the parent directory is never injected into the
+    interpreter's import paths.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"could not build import spec for {path} as {module_name}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/src/agentlings/tools/registry.py
+++ b/src/agentlings/tools/registry.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from agentlings.tools.decorator import Tool
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,35 @@ class ToolRegistry:
             execute_fn=execute_fn,
         )
         logger.info("registered tool: %s", name)
+
+    def register_tool_object(self, tool: "Tool[Any]") -> None:
+        """Register a ``@tool``-decorated ``Tool`` instance.
+
+        Bridges the decorator surface to the existing registry shape: the
+        tool's input schema and metadata are extracted via
+        ``to_anthropic_dict()``; execution is wrapped so a unified
+        ``ToolResult`` is returned regardless of the underlying function's
+        return type.
+
+        Args:
+            tool: The ``Tool`` produced by the ``@tool`` decorator.
+        """
+        async def _execute(**kwargs: Any) -> ToolResult:
+            try:
+                output = await tool.call(kwargs)
+            except Exception as e:  # noqa: BLE001 — surface to LLM, not crash
+                return ToolResult(
+                    output=f"Tool {tool.name} failed: {e}",
+                    is_error=True,
+                )
+            return ToolResult(output=str(output), is_error=False)
+
+        self.register(
+            name=tool.name,
+            description=tool.description,
+            input_schema=tool.input_schema,
+            execute_fn=_execute,
+        )
 
     def list_schemas(self) -> list[dict[str, Any]]:
         """Return tool schemas in the format expected by the Anthropic API."""

--- a/tests/unit/test_tool_decorator.py
+++ b/tests/unit/test_tool_decorator.py
@@ -1,0 +1,383 @@
+"""Tests for ``agentlings.tools.decorator`` — schema inference, validation,
+sync/async dispatch, and rejection of unsupported signatures."""
+
+from __future__ import annotations
+
+import asyncio
+from enum import Enum, IntEnum
+from typing import Annotated, Literal, Optional
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from agentlings.tools import Tool, ToolDefinitionError, ToolInputError, tool
+
+
+# --------------------------------------------------------------------------- #
+# Decorator surface — bare, parenthesized, and overrides
+# --------------------------------------------------------------------------- #
+
+
+class TestDecoratorSurface:
+    def test_bare_decorator(self) -> None:
+        @tool
+        def hello(name: str) -> str:
+            """Say hi."""
+            return f"hi {name}"
+
+        assert isinstance(hello, Tool)
+        assert hello.name == "hello"
+        assert hello.description == "Say hi."
+
+    def test_parenthesized_decorator_with_overrides(self) -> None:
+        @tool(name="greet", description="custom")
+        def hello(name: str) -> str:
+            """ignored docstring"""
+            return name
+
+        assert hello.name == "greet"
+        assert hello.description == "custom"
+
+    def test_description_falls_back_to_docstring_full_text(self) -> None:
+        @tool
+        def f(x: int) -> int:
+            """Short summary.
+
+            Longer description spanning
+            multiple lines.
+            """
+            return x
+
+        assert f.description.startswith("Short summary.")
+        assert "Longer description" in f.description
+
+    def test_no_docstring_yields_empty_description(self) -> None:
+        @tool
+        def f(x: int) -> int:
+            return x
+
+        assert f.description == ""
+
+
+# --------------------------------------------------------------------------- #
+# Schema inference — primitives, Optional, defaults
+# --------------------------------------------------------------------------- #
+
+
+class TestSchemaPrimitives:
+    def test_primitives_map_to_json_schema_types(self) -> None:
+        @tool
+        def f(s: str, i: int, fl: float, b: bool) -> None:
+            """t"""
+
+        props = f.input_schema["properties"]
+        assert props["s"]["type"] == "string"
+        assert props["i"]["type"] == "integer"
+        assert props["fl"]["type"] == "number"
+        assert props["b"]["type"] == "boolean"
+        assert set(f.input_schema["required"]) == {"s", "i", "fl", "b"}
+
+    def test_optional_param_is_not_required(self) -> None:
+        @tool
+        def f(name: str, nickname: Optional[str] = None) -> None:
+            """t"""
+
+        assert f.input_schema["required"] == ["name"]
+        # Optional[str] becomes anyOf[string, null] in Pydantic v2.
+        nickname = f.input_schema["properties"]["nickname"]
+        assert "anyOf" in nickname or nickname.get("type") in ("string", ["string", "null"])
+
+    def test_default_value_is_advertised(self) -> None:
+        @tool
+        def f(timeout_seconds: int = 30) -> None:
+            """t"""
+
+        prop = f.input_schema["properties"]["timeout_seconds"]
+        assert prop["default"] == 30
+        assert "timeout_seconds" not in f.input_schema.get("required", [])
+
+    def test_top_level_title_is_stripped(self) -> None:
+        @tool
+        def f(x: int) -> None:
+            """t"""
+
+        assert "title" not in f.input_schema
+
+
+# --------------------------------------------------------------------------- #
+# Schema inference — string and integer enums, Literal
+# --------------------------------------------------------------------------- #
+
+
+class Severity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class Priority(IntEnum):
+    P0 = 0
+    P1 = 1
+    P2 = 2
+
+
+class TestEnumsAndLiterals:
+    def test_str_enum_renders_as_string_with_enum_values(self) -> None:
+        @tool
+        def f(severity: Severity) -> None:
+            """t"""
+
+        # Pydantic emits enums via $ref to a $defs entry.
+        schema = f.input_schema
+        assert "$defs" in schema
+        # Find the Severity definition.
+        defs = schema["$defs"]
+        sev_def = next(iter(defs.values()))
+        assert sev_def["type"] == "string"
+        assert set(sev_def["enum"]) == {"low", "medium", "high"}
+
+    def test_int_enum_renders_as_integer_with_enum_values(self) -> None:
+        @tool
+        def f(priority: Priority) -> None:
+            """t"""
+
+        defs = f.input_schema["$defs"]
+        pri_def = next(iter(defs.values()))
+        assert pri_def["type"] == "integer"
+        assert set(pri_def["enum"]) == {0, 1, 2}
+
+    def test_literal_strings_render_inline_as_enum(self) -> None:
+        @tool
+        def f(method: Literal["GET", "POST", "DELETE"]) -> None:
+            """t"""
+
+        prop = f.input_schema["properties"]["method"]
+        # Literal of strings inlines an enum, no $defs entry.
+        assert set(prop["enum"]) == {"GET", "POST", "DELETE"}
+        # Pydantic v2 may or may not include `type: string` for Literal —
+        # tolerate either, but if present it must be string.
+        assert prop.get("type", "string") == "string"
+
+    @pytest.mark.asyncio
+    async def test_str_enum_validates_and_passes_native_value(self) -> None:
+        captured: dict[str, Severity] = {}
+
+        @tool
+        def record(severity: Severity) -> str:
+            """t"""
+            captured["v"] = severity
+            return severity.value
+
+        result = await record.call({"severity": "high"})
+        assert result == "high"
+        assert captured["v"] is Severity.HIGH
+
+    @pytest.mark.asyncio
+    async def test_invalid_enum_value_raises_tool_input_error(self) -> None:
+        @tool
+        def f(severity: Severity) -> None:
+            """t"""
+
+        with pytest.raises(ToolInputError) as exc_info:
+            await f.call({"severity": "extreme"})
+        assert isinstance(exc_info.value.validation_error, ValidationError)
+
+
+# --------------------------------------------------------------------------- #
+# Annotated[..., Field(...)] — descriptions, constraints
+# --------------------------------------------------------------------------- #
+
+
+class TestAnnotatedFieldMetadata:
+    def test_annotated_field_description_appears_in_schema(self) -> None:
+        @tool
+        def f(
+            url: Annotated[str, Field(description="The URL to fetch")],
+        ) -> None:
+            """t"""
+
+        assert f.input_schema["properties"]["url"]["description"] == "The URL to fetch"
+
+    def test_annotated_constraints_apply_at_validation(self) -> None:
+        @tool
+        def f(
+            n: Annotated[int, Field(ge=1, le=10)],
+        ) -> int:
+            """t"""
+            return n
+
+        prop = f.input_schema["properties"]["n"]
+        assert prop["minimum"] == 1
+        assert prop["maximum"] == 10
+
+
+# --------------------------------------------------------------------------- #
+# Nested Pydantic models, lists, dicts
+# --------------------------------------------------------------------------- #
+
+
+class Coordinates(BaseModel):
+    lat: float
+    lng: float
+
+
+class TestComplexTypes:
+    def test_pydantic_model_param_yields_ref_and_definition(self) -> None:
+        @tool
+        def f(loc: Coordinates) -> None:
+            """t"""
+
+        prop = f.input_schema["properties"]["loc"]
+        assert "$ref" in prop
+        assert "$defs" in f.input_schema
+        coord_def = f.input_schema["$defs"]["Coordinates"]
+        assert coord_def["type"] == "object"
+        assert set(coord_def["properties"].keys()) == {"lat", "lng"}
+
+    def test_list_of_strings(self) -> None:
+        @tool
+        def f(tags: list[str]) -> None:
+            """t"""
+
+        prop = f.input_schema["properties"]["tags"]
+        assert prop["type"] == "array"
+        assert prop["items"]["type"] == "string"
+
+    def test_dict_with_typed_values(self) -> None:
+        @tool
+        def f(headers: dict[str, str]) -> None:
+            """t"""
+
+        prop = f.input_schema["properties"]["headers"]
+        assert prop["type"] == "object"
+        # Pydantic emits additionalProperties as the value type schema.
+        assert prop["additionalProperties"]["type"] == "string"
+
+    @pytest.mark.asyncio
+    async def test_pydantic_model_arg_is_constructed_and_passed(self) -> None:
+        captured: dict[str, Coordinates] = {}
+
+        @tool
+        def f(loc: Coordinates) -> str:
+            """t"""
+            captured["loc"] = loc
+            return f"{loc.lat},{loc.lng}"
+
+        out = await f.call({"loc": {"lat": 1.5, "lng": -2.0}})
+        assert out == "1.5,-2.0"
+        assert isinstance(captured["loc"], Coordinates)
+        assert captured["loc"].lat == 1.5
+
+
+# --------------------------------------------------------------------------- #
+# Sync vs async dispatch
+# --------------------------------------------------------------------------- #
+
+
+class TestSyncAndAsync:
+    @pytest.mark.asyncio
+    async def test_sync_tool_runs_via_to_thread(self) -> None:
+        @tool
+        def add(a: int, b: int) -> int:
+            """t"""
+            return a + b
+
+        assert add.is_async is False
+        assert await add.call({"a": 2, "b": 3}) == 5
+
+    @pytest.mark.asyncio
+    async def test_async_tool_is_awaited(self) -> None:
+        @tool
+        async def add(a: int, b: int) -> int:
+            """t"""
+            await asyncio.sleep(0)
+            return a + b
+
+        assert add.is_async is True
+        assert await add.call({"a": 2, "b": 3}) == 5
+
+
+# --------------------------------------------------------------------------- #
+# Rejection of unsupported signatures
+# --------------------------------------------------------------------------- #
+
+
+class TestRejectedSignatures:
+    def test_missing_annotation_raises(self) -> None:
+        with pytest.raises(ToolDefinitionError, match="must have a type annotation"):
+            @tool
+            def f(x) -> None:  # type: ignore[no-untyped-def]
+                """t"""
+
+    def test_var_args_rejected(self) -> None:
+        with pytest.raises(ToolDefinitionError, match=r"\*args"):
+            @tool
+            def f(*args: int) -> None:
+                """t"""
+
+    def test_var_kwargs_rejected(self) -> None:
+        with pytest.raises(ToolDefinitionError, match=r"\*\*kwargs"):
+            @tool
+            def f(**kwargs: int) -> None:
+                """t"""
+
+    def test_positional_only_rejected(self) -> None:
+        with pytest.raises(ToolDefinitionError, match="positional-only"):
+            @tool
+            def f(x: int, /) -> None:
+                """t"""
+
+
+# --------------------------------------------------------------------------- #
+# to_anthropic_dict — exact shape contract
+# --------------------------------------------------------------------------- #
+
+
+class TestAnthropicDictShape:
+    def test_to_anthropic_dict_contains_expected_keys_only(self) -> None:
+        @tool
+        def f(x: int) -> None:
+            """A short tool."""
+
+        d = f.to_anthropic_dict()
+        assert set(d.keys()) == {"name", "description", "input_schema"}
+        assert d["name"] == "f"
+        assert d["description"] == "A short tool."
+        assert d["input_schema"]["type"] == "object"
+        assert "x" in d["input_schema"]["properties"]
+
+    def test_repeat_calls_return_equivalent_dicts(self) -> None:
+        @tool
+        def f(x: int) -> None:
+            """t"""
+
+        assert f.to_anthropic_dict() == f.to_anthropic_dict()
+
+
+# --------------------------------------------------------------------------- #
+# Generic invocation behavior
+# --------------------------------------------------------------------------- #
+
+
+class TestCallBehavior:
+    @pytest.mark.asyncio
+    async def test_extra_keys_rejected_by_default(self) -> None:
+        @tool
+        def f(x: int) -> int:
+            """t"""
+            return x
+
+        # Pydantic's default model_config allows extra fields silently;
+        # they're simply ignored. Confirm that's the behavior so callers can
+        # rely on it (and we document the contract).
+        assert await f.call({"x": 1, "junk": True}) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_required_param_raises_tool_input_error(self) -> None:
+        @tool
+        def f(x: int, y: int) -> int:
+            """t"""
+            return x + y
+
+        with pytest.raises(ToolInputError):
+            await f.call({"x": 1})

--- a/tests/unit/test_tool_loader.py
+++ b/tests/unit/test_tool_loader.py
@@ -1,0 +1,291 @@
+"""Tests for ``ToolRegistry.register_tool_object`` and the folder-scan loader."""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agentlings.tools import tool
+from agentlings.tools.loader import load_tools_from_directory
+from agentlings.tools.registry import ToolRegistry
+
+
+# --------------------------------------------------------------------------- #
+# Registry integration
+# --------------------------------------------------------------------------- #
+
+
+class TestRegisterToolObject:
+    def test_registers_name_description_and_schema(self) -> None:
+        @tool
+        def adder(a: int, b: int) -> int:
+            """Add two integers."""
+            return a + b
+
+        registry = ToolRegistry()
+        registry.register_tool_object(adder)
+
+        schemas = registry.list_schemas()
+        assert len(schemas) == 1
+        s = schemas[0]
+        assert s["name"] == "adder"
+        assert s["description"] == "Add two integers."
+        assert s["input_schema"]["type"] == "object"
+        assert set(s["input_schema"]["properties"].keys()) == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_tool_result_with_output(self) -> None:
+        @tool
+        def adder(a: int, b: int) -> int:
+            """t"""
+            return a + b
+
+        registry = ToolRegistry()
+        registry.register_tool_object(adder)
+
+        result = await registry.execute("adder", {"a": 2, "b": 3})
+        assert result.is_error is False
+        assert result.output == "5"
+
+    @pytest.mark.asyncio
+    async def test_async_tool_executes_through_registry(self) -> None:
+        @tool
+        async def reverse(s: str) -> str:
+            """t"""
+            return s[::-1]
+
+        registry = ToolRegistry()
+        registry.register_tool_object(reverse)
+
+        result = await registry.execute("reverse", {"s": "hello"})
+        assert result.output == "olleh"
+        assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_surfaces_as_error_result(self) -> None:
+        """Bad inputs must come back as is_error=True, not raise — the LLM
+        retries with corrected args."""
+        @tool
+        def adder(a: int, b: int) -> int:
+            """t"""
+            return a + b
+
+        registry = ToolRegistry()
+        registry.register_tool_object(adder)
+
+        result = await registry.execute("adder", {"a": "not-an-int", "b": 1})
+        assert result.is_error is True
+        assert "adder" in result.output
+
+    @pytest.mark.asyncio
+    async def test_runtime_exception_surfaces_as_error_result(self) -> None:
+        @tool
+        def boom(x: int) -> int:
+            """t"""
+            raise RuntimeError("nope")
+
+        registry = ToolRegistry()
+        registry.register_tool_object(boom)
+
+        result = await registry.execute("boom", {"x": 1})
+        assert result.is_error is True
+        assert "boom" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Folder scan loader
+# --------------------------------------------------------------------------- #
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip())
+
+
+class TestFolderScan:
+    def test_loads_tools_from_directory(self, tmp_path: Path) -> None:
+        _write(tmp_path / "greet.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def greet(name: str) -> str:
+                "Say hi."
+                return f"hi {name}"
+        """)
+
+        registry = ToolRegistry()
+        names = load_tools_from_directory(tmp_path, registry)
+
+        assert names == ["greet"]
+        assert "greet" in registry.tool_names()
+
+    def test_loads_multiple_tools_per_file(self, tmp_path: Path) -> None:
+        _write(tmp_path / "math_ops.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def add(a: int, b: int) -> int:
+                "t"
+                return a + b
+
+            @tool
+            def sub(a: int, b: int) -> int:
+                "t"
+                return a - b
+        """)
+
+        registry = ToolRegistry()
+        names = load_tools_from_directory(tmp_path, registry)
+
+        assert sorted(names) == ["add", "sub"]
+        assert set(registry.tool_names()) == {"add", "sub"}
+
+    def test_skips_files_starting_with_underscore(self, tmp_path: Path) -> None:
+        _write(tmp_path / "_private.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def secret(x: int) -> int:
+                "t"
+                return x
+        """)
+        _write(tmp_path / "public.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def hello(x: int) -> int:
+                "t"
+                return x
+        """)
+
+        registry = ToolRegistry()
+        names = load_tools_from_directory(tmp_path, registry)
+
+        assert names == ["hello"]
+        assert "secret" not in registry.tool_names()
+
+    def test_ignores_non_python_files(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# tools")
+        (tmp_path / "config.yaml").write_text("foo: bar")
+        _write(tmp_path / "real.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def alive(x: int) -> int:
+                "t"
+                return x
+        """)
+
+        registry = ToolRegistry()
+        names = load_tools_from_directory(tmp_path, registry)
+
+        assert names == ["alive"]
+
+    def test_does_not_recurse_into_subdirs(self, tmp_path: Path) -> None:
+        sub = tmp_path / "nested"
+        sub.mkdir()
+        _write(sub / "buried.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def buried(x: int) -> int:
+                "t"
+                return x
+        """)
+
+        registry = ToolRegistry()
+        names = load_tools_from_directory(tmp_path, registry)
+        assert names == []
+        assert "buried" not in registry.tool_names()
+
+    def test_broken_file_is_logged_and_skipped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write(tmp_path / "broken.py", "this is not valid python {")
+        _write(tmp_path / "good.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def ok(x: int) -> int:
+                "t"
+                return x
+        """)
+
+        registry = ToolRegistry()
+        with caplog.at_level(logging.ERROR, logger="agentlings.tools.loader"):
+            names = load_tools_from_directory(tmp_path, registry)
+
+        assert names == ["ok"], "good tool must still register despite broken neighbor"
+        assert any("broken.py" in r.message for r in caplog.records), \
+            "broken file must be logged"
+
+    def test_missing_directory_logs_and_returns_empty(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        missing = tmp_path / "does-not-exist"
+        registry = ToolRegistry()
+        with caplog.at_level(logging.INFO, logger="agentlings.tools.loader"):
+            names = load_tools_from_directory(missing, registry)
+
+        assert names == []
+        assert any("does not exist" in r.message for r in caplog.records)
+
+    def test_path_pointing_at_a_file_is_rejected(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        f = tmp_path / "not-a-dir.py"
+        f.write_text("# nothing")
+        registry = ToolRegistry()
+        with caplog.at_level(logging.WARNING, logger="agentlings.tools.loader"):
+            names = load_tools_from_directory(f, registry)
+
+        assert names == []
+        assert any("not a directory" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_loaded_tool_is_executable_through_registry(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: a user file → registry → execute returns the result."""
+        _write(tmp_path / "shouty.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def shout(message: str) -> str:
+                "t"
+                return message.upper()
+        """)
+
+        registry = ToolRegistry()
+        load_tools_from_directory(tmp_path, registry)
+
+        result = await registry.execute("shout", {"message": "hello"})
+        assert result.is_error is False
+        assert result.output == "HELLO"
+
+    def test_module_isolation_does_not_pollute_sys_path(
+        self, tmp_path: Path
+    ) -> None:
+        """The user-tools dir must not be injected into sys.path — otherwise a
+        user could shadow installed packages by naming a file ``json.py``."""
+        import sys
+
+        before = list(sys.path)
+        _write(tmp_path / "trivial.py", """
+            from agentlings.tools import tool
+
+            @tool
+            def t(x: int) -> int:
+                "t"
+                return x
+        """)
+
+        registry = ToolRegistry()
+        load_tools_from_directory(tmp_path, registry)
+
+        # sys.path entries must not include the user tools dir.
+        assert str(tmp_path) not in sys.path
+        # And nothing else should have been added either.
+        assert sys.path == before


### PR DESCRIPTION
Tools become first-class authorable artifacts: a typed Python function becomes a self-describing tool whose JSON Schema is derived from its signature via Pydantic, no hand-maintained schema dicts. On startup the agentling scans `AGENT_TOOLS_DIR` for `.py` files and registers every module-level `Tool` instance into the existing `ToolRegistry`, so users can drop a file in a directory and have it picked up without modifying framework code.

- `agentlings.tools.decorator`: `@tool` decorator + `Tool` class. Schema via `pydantic.create_model` from the typed signature; per-param description and constraints via `Annotated[T, Field(...)]`. Sync and async unified behind `Tool.call(args)`. Rejects untyped params, `*args`, `**kwargs`, and positional-only params at decoration time.
- `agentlings.tools.loader.load_tools_from_directory`: imports each `.py` via `importlib.util.spec_from_file_location` (no `sys.path` pollution), registers module-level `Tool` instances, and logs+continues on import failure so one broken file can't brick the agent. Skips files starting with `_`, ignores non-`.py`, no recursion.
- `ToolRegistry.register_tool_object` adapts a `Tool` to the existing registry; validation and runtime errors surface as `ToolResult(is_error=True)` so the LLM retries instead of crashing.
- `AGENT_TOOLS_DIR` added to `AgentConfig`; `server._create_app` invokes the loader after the builtin registration.
- Reference tools in `agentlings.tools.examples`: minimal `echo`, async I/O with `Annotated` descriptions, str `Enum` parameter, env-var-driven config + nested `BaseModel`.
- 44 new unit tests across decorator, registry integration, and folder-scan behavior.
- Bumps version to 0.2.4.