### PR TITLE
feat: make agent_skills_dir opt-in to match agent_tools_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Step-by-step instructions for the agent go below the frontmatter.
 Reference companion files with relative paths, e.g. `scripts/extract.py`.
 ```
 
-Drop skill directories under `./skills` (or anywhere — point `AGENT_SKILLS_DIR` at it). On startup the agentling discovers them and prepends a single block to the system prompt explaining progressive disclosure and listing each skill's name, absolute path, and description. The agent reads `SKILL.md` itself when a task calls for the skill.
+Skills are opt-in: set `AGENT_SKILLS_DIR=./skills` (or any path) and drop skill directories there. On startup the agentling discovers them and prepends a single block to the system prompt explaining progressive disclosure and listing each skill's name, absolute path, and description. The agent reads `SKILL.md` itself when a task calls for the skill.
 
 ### Frontmatter constraints
 
@@ -283,7 +283,7 @@ Per the Open Skills spec:
 
 Optional fields (`license`, `compatibility`, `metadata`, `allowed-tools`) are accepted but currently ignored at the runtime layer. Malformed skills (missing fields, invalid names, broken YAML) are logged at `WARNING` and skipped — one bad skill does not prevent the agent from booting.
 
-Discovery is strictly read-only — the agentling never writes to, deletes from, or modifies anything under `AGENT_SKILLS_DIR`. `agentling init` does not create the directory either; if you don't put one there, discovery is a no-op and no skills block is added to the prompt. The same applies to `AGENT_TOOLS_DIR`: scans are read-only and the user-tools directory is never added to `sys.path`, so a file named `json.py` cannot shadow the stdlib.
+Discovery is strictly read-only — the agentling never writes to, deletes from, or modifies anything under `AGENT_SKILLS_DIR`. `AGENT_SKILLS_DIR` and `AGENT_TOOLS_DIR` share the same opt-in semantics: unset means "don't scan." `AGENT_TOOLS_DIR` additionally never adds the user-tools directory to `sys.path`, so a file named `json.py` cannot shadow the stdlib.
 
 > **Naming note:** the `skills:` array in `agent.yaml` is unrelated — those are A2A Agent Card capabilities advertised on the wire. Runtime skills (this section) live on disk under `AGENT_SKILLS_DIR`.
 
@@ -324,7 +324,7 @@ Secrets and runtime settings stay in env vars or, more commonly, the `.env` file
 | `AGENT_PORT` | `8420` | Bind port |
 | `AGENT_DATA_DIR` | `./data` | JSONL journal storage directory |
 | `AGENT_TOOLS_DIR` | — | Directory of `@tool`-decorated `.py` files to load at startup |
-| `AGENT_SKILLS_DIR` | `./skills` | Directory of Open Skills `SKILL.md` bundles to advertise to the agent |
+| `AGENT_SKILLS_DIR` | — | Directory of Open Skills `SKILL.md` bundles to advertise to the agent |
 | `AGENT_TASK_AWAIT_SECONDS` | `60` | How long the HTTP handler blocks for task completion before returning a working task handle |
 | `AGENT_LOG_LEVEL` | `INFO` | Log level |
 | `AGENT_LLM_BACKEND` | `anthropic` | `anthropic` or `mock` |

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ my-agent/
 ├── .env                 # AGENT_API_KEY auto-generated; ANTHROPIC_API_KEY blank for you
 ├── .env.example         # checked into source control as a template
 ├── .framework-version   # the framework version that scaffolded this dir
-└── data/                # journals, memory, conversations
-    └── .migrations      # applied-migrations log
+├── data/                # journals, memory, conversations
+│   └── .migrations      # applied-migrations log
+├── skills/              # drop SKILL.md bundles here; uncomment AGENT_SKILLS_DIR to enable
+└── tools/               # drop @tool-decorated .py files here; uncomment AGENT_TOOLS_DIR to enable
 ```
 
 `agentling run` reads `agent.yaml`, `.env`, and `data/` from the current directory. To operate on a different dir without `cd`-ing in: `agentling run --dir /path/to/agent`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.3.1"
+version = "0.4.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.3.0"
+version = "0.3.1"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/cli/init.py
+++ b/src/agentlings/cli/init.py
@@ -18,6 +18,8 @@ from agentlings.cli import _migrations, _templates, _version
 logger = logging.getLogger(__name__)
 
 DATA_DIRNAME = "data"
+SKILLS_DIRNAME = "skills"
+TOOLS_DIRNAME = "tools"
 ENV_FILENAME = ".env"
 ENV_EXAMPLE_FILENAME = ".env.example"
 YAML_FILENAME = "agent.yaml"
@@ -64,6 +66,8 @@ def init_agent(
 
     target.mkdir(parents=True, exist_ok=True)
     (target / DATA_DIRNAME).mkdir(exist_ok=True)
+    (target / SKILLS_DIRNAME).mkdir(exist_ok=True)
+    (target / TOOLS_DIRNAME).mkdir(exist_ok=True)
 
     yaml_path = target / YAML_FILENAME
     if not yaml_path.exists() or force:

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -153,7 +153,7 @@ class AgentConfig(BaseSettings):
     agent_host: str = "0.0.0.0"
     agent_port: int = 8420
     agent_data_dir: Path = Path("./data")
-    agent_skills_dir: Path = Path("./skills")
+    agent_skills_dir: Path | None = None
     agent_log_level: str = "INFO"
     agent_llm_backend: Literal["anthropic", "mock"] = "anthropic"
     agent_external_url: str | None = None
@@ -205,8 +205,13 @@ class AgentConfig(BaseSettings):
         return self._definition.skills
 
     @property
-    def skills_dir(self) -> Path:
-        """Filesystem root for runtime instruction-skills (Open Skills spec)."""
+    def skills_dir(self) -> Path | None:
+        """Filesystem root for runtime instruction-skills (Open Skills spec).
+
+        Opt-in: when ``AGENT_SKILLS_DIR`` is unset, the agent does not scan
+        anywhere. This matches ``AGENT_TOOLS_DIR`` so the two folder-scan
+        env vars share one mental model.
+        """
         return self.agent_skills_dir
 
     @property

--- a/src/agentlings/core/skills.py
+++ b/src/agentlings/core/skills.py
@@ -9,9 +9,11 @@ pattern from the Open Skills specification (https://agentskills.io/specification
 
 Discovery is intentionally lenient: malformed entries are logged and skipped so
 one broken skill does not prevent the agent from booting. It is also strictly
-read-only — no mkdir, no writes, no imports, no ``sys.path`` mutation — so a
-pre-existing ``./skills`` directory in the user's working tree (e.g. from an
-unrelated project) cannot be clobbered by the agent.
+read-only — no mkdir, no writes, no imports, no ``sys.path`` mutation — so an
+existing skills root in the user's filesystem (e.g. from an unrelated project)
+cannot be clobbered by the agent. Discovery itself only runs when the operator
+sets ``AGENT_SKILLS_DIR``; an unset value is a no-op, matching the opt-in
+semantics of ``AGENT_TOOLS_DIR``.
 """
 
 from __future__ import annotations

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -111,7 +111,7 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         base_url=config.anthropic_base_url,
     )
 
-    skills = discover_skills(config.skills_dir)
+    skills = discover_skills(config.skills_dir) if config.skills_dir else []
     if skills:
         logger.info(
             "loaded %d skill(s) from %s: %s",

--- a/src/agentlings/templates/default/.env.example
+++ b/src/agentlings/templates/default/.env.example
@@ -14,3 +14,8 @@ AGENT_API_KEY=
 # AGENT_MODEL=claude-sonnet-4-6
 # AGENT_PORT=8420
 # AGENT_LOG_LEVEL=INFO
+
+# Folder-scan integrations (opt-in). `agentling init` scaffolds empty
+# `skills/` and `tools/` directories; uncomment these to enable scanning.
+# AGENT_SKILLS_DIR=./skills
+# AGENT_TOOLS_DIR=./tools

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -21,6 +21,23 @@ class TestScaffoldLayout:
         assert (agent_dir / ".framework-version").is_file()
         assert (agent_dir / "data").is_dir()
 
+    def test_creates_skills_and_tools_dirs(self, tmp_path: Path) -> None:
+        """Both folder-scan integrations get an empty drop-zone scaffolded.
+
+        Operators uncomment the matching env var in ``.env`` to enable
+        scanning. The directories are created empty so the convention is
+        self-documenting without auto-activating either integration.
+        """
+        result = init_agent("my-agent", dir=tmp_path / "my-agent")
+        assert (result.agent_dir / "skills").is_dir()
+        assert (result.agent_dir / "tools").is_dir()
+
+    def test_env_example_documents_folder_scan_vars(self, tmp_path: Path) -> None:
+        result = init_agent("my-agent", dir=tmp_path / "my-agent")
+        env_example = (result.agent_dir / ".env.example").read_text()
+        assert "AGENT_SKILLS_DIR=./skills" in env_example
+        assert "AGENT_TOOLS_DIR=./tools" in env_example
+
     def test_yaml_substitutes_name(self, tmp_path: Path) -> None:
         result = init_agent("my-agent", dir=tmp_path / "my-agent")
         text = (result.agent_dir / "agent.yaml").read_text(encoding="utf-8")
@@ -101,6 +118,18 @@ class TestIdempotency:
         (target / "data" / "important.txt").write_text("KEEP ME")
         init_agent("a", dir=target, force=True)
         assert (target / "data" / "important.txt").read_text() == "KEEP ME"
+
+    def test_force_preserves_skills_and_tools_content(self, tmp_path: Path) -> None:
+        """``--force`` re-scaffolds metadata files but never touches user content
+        the operator may have dropped under ``skills/`` or ``tools/``."""
+        target = tmp_path / "agent"
+        init_agent("a", dir=target)
+        (target / "skills" / "pdf-processing").mkdir()
+        (target / "skills" / "pdf-processing" / "SKILL.md").write_text("---\nname: pdf-processing\ndescription: pdfs\n---\n")
+        (target / "tools" / "weather.py").write_text("# user tool\n")
+        init_agent("a", dir=target, force=True)
+        assert (target / "skills" / "pdf-processing" / "SKILL.md").is_file()
+        assert (target / "tools" / "weather.py").read_text() == "# user tool\n"
 
     def test_force_preserves_existing_env(self, tmp_path: Path) -> None:
         """Re-running init must never clobber an operator's filled-in .env."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,6 +59,35 @@ def test_default_agent_identity(tmp_path: Path) -> None:
     assert config.system_prompt is None
 
 
+def test_skills_and_tools_dirs_opt_in_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both folder-scan env vars share opt-in semantics: unset means no scan."""
+    monkeypatch.delenv("AGENT_SKILLS_DIR", raising=False)
+    monkeypatch.delenv("AGENT_TOOLS_DIR", raising=False)
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path,
+        _env_file=None,
+    )
+    assert config.skills_dir is None
+    assert config.agent_tools_dir is None
+
+
+def test_skills_dir_from_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_SKILLS_DIR", str(tmp_path / "skills"))
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path,
+        _env_file=None,
+    )
+    assert config.skills_dir == tmp_path / "skills"
+
+
 def test_data_dir_created(tmp_path: Path) -> None:
     data_dir = tmp_path / "nested" / "data"
     assert not data_dir.exists()


### PR DESCRIPTION
Why: AGENT_SKILLS_DIR auto-scanned ./skills while AGENT_TOOLS_DIR required an explicit value — two similarly-named env vars with opposite default semantics is a footgun for operators.

- AgentConfig.agent_skills_dir defaults to None; unset means "do not scan".
- Server skips discovery entirely when skills_dir is None — the prompt has no skills block and the discovery code path is never entered.
- README and skills.py docstring rewritten so the shared opt-in story for AGENT_SKILLS_DIR and AGENT_TOOLS_DIR is the lead, not a footnote.
- Two new test_config cases pin both vars to None by default and verify AGENT_SKILLS_DIR round-trips from the environment.
- Bumps version to 0.3.1.