### PR TITLE
feat: comprehensive telemetry across requests, tasks, llm, tools, and journals

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ The agent is told about this directory structure and can use its filesystem tool
 
 ## OpenTelemetry
 
-The sleep cycle and memory tool emit spans and metrics to an OpenTelemetry collector when telemetry is enabled.
+Off by default. When enabled, the framework emits a comprehensive trace + metric surface over OTLP — every HTTP request, every protocol call, every task, every LLM completion, every tool, and every journal write.
 
 ```yaml
 telemetry:
@@ -470,10 +470,70 @@ telemetry:
     Authorization: "Bearer your-token"
 ```
 
-Or via env vars: `AGENT_OTEL_ENDPOINT=http://collector:4318 AGENT_OTEL_HEADERS="Authorization=Bearer tok"`.
+Or via env vars (these override the YAML and force `enabled: true`):
 
+```bash
+AGENT_OTEL_ENDPOINT=http://collector:4318
+AGENT_OTEL_PROTOCOL=http      # or grpc
+AGENT_OTEL_INSECURE=true
+AGENT_OTEL_HEADERS="Authorization=Bearer tok,X-Tenant=team-a"
+```
 
-When telemetry is disabled (the default) or the OpenTelemetry packages are not installed, all instrumentation is a no-op.
+### Spans emitted
+
+A request flows top-to-bottom through this tree, parent → child:
+
+| Span | Where |
+|---|---|
+| `agentling.http.request` | Starlette middleware. Extracts inbound `traceparent` so external traces stitch in. |
+| `agentling.a2a.execute` / `agentling.a2a.cancel` | A2A executor. |
+| `agentling.mcp.call_tool` | MCP server. |
+| `agentling.engine.spawn` / `.poll` / `.cancel` | Task engine entry points. |
+| `agentling.task.worker` | Per-task worker. Stamps token totals as attributes. |
+| `agentling.completion` | LLM completion cycle. Stamps cycle-wide token totals. |
+| `agentling.completion.llm_call` | One LLM turn. Per-turn token attributes. |
+| `agentling.completion.tool_exec` | Per-tool execution within a turn. |
+| `agentling.llm.complete` / `.count_tokens` / `.batch_create` / `.batch_status` / `.batch_results` | LLM client calls. Token usage attributes on the `complete` span. |
+| `agentling.engine.recovery` | Startup crash-recovery pass. |
+| `agentling.sleep.*` | Nightly sleep cycle phases (when enabled). |
+| `agentling.memory.list/set/remove` | Memory tool operations. |
+
+### Metrics emitted
+
+**Tokens** (per-call histograms + monotonic counters, labeled by `llm.model`, `llm.path` of `live`/`batch`):
+
+- `agentling.llm.input_tokens` / `_total`
+- `agentling.llm.output_tokens` / `_total`
+- `agentling.llm.cache_creation_input_tokens` / `_total`
+- `agentling.llm.cache_read_input_tokens` / `_total`
+- `agentling.llm.total_tokens`
+- `agentling.llm.cache_hit_ratio`
+- `agentling.llm.calls_total`
+
+**Tasks** (counters + active gauge):
+
+- `agentling.tasks.spawned_total` / `completed_total` / `failed_total` / `cancelled_total`
+- `agentling.tasks.active`
+- `agentling.tasks.context_busy_rejections_total`
+- `agentling.tasks.crash_recovery_repaired_total` / `crash_recovery_failed_total`
+
+**Completion + tools**:
+
+- `agentling.completion.duration_seconds`, `.turns`
+- `agentling.tool.calls`, `.errors`, `.duration_seconds` (labeled by `tool.name`, `tool.is_error`)
+
+**Journal I/O**:
+
+- `agentling.journal.append_seconds` (labeled by `journal.target=parent|sub`)
+- `agentling.journal.replay_seconds`
+- `agentling.journal.bytes_appended_total`
+- `agentling.journal.entries_replayed_total`
+
+**HTTP**:
+
+- `agentling.http.request` span carries `http.status_code`, `http.duration_seconds`, `http.method`, `http.target`.
+
+When telemetry is disabled (the default) or the OpenTelemetry packages are not installed, all instrumentation is a no-op — the cost is one function call per span/metric site.
 
 ## Architecture
 

--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -35,8 +35,14 @@ sleep:
   # consolidation_prompt: null  # override REM consolidation prompt
 
 telemetry:
+  # Off by default. When enabled, the agent emits OTLP traces + metrics
+  # for every HTTP request, protocol call, task, LLM call, tool, and
+  # journal write. See README "OpenTelemetry" for the full span/metric
+  # surface. Override at runtime via AGENT_OTEL_ENDPOINT (and friends).
   enabled: false
-  endpoint: "http://localhost:4318"
-  protocol: "http"
+  endpoint: "http://localhost:4318"   # OTLP collector base URL
+  protocol: "http"                    # "http" or "grpc"
   service_name: "agentling"
-  insecure: true
+  insecure: true                      # disable TLS for collector connection
+  # headers:
+  #   Authorization: "Bearer your-token"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.4.0"
+version = "0.5.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/completion.py
+++ b/src/agentlings/core/completion.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 from agentlings.core.llm import BaseLLMClient, LLMResponse
-from agentlings.core.telemetry import get_meter, otel_span
+from agentlings.core.telemetry import get_meter, otel_span, record_tool_duration
 from agentlings.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -72,11 +72,21 @@ class CompletionResult:
         content: Anthropic-format content blocks from the final LLM response.
         stop_reason: Why the model stopped generating.
         turns: Every turn in the cycle, each pairing an LLM response with its tool results.
+        token_usage: Sum of token usage across every turn in the cycle.
+            Keys: ``input``, ``output``, ``cache_creation``, ``cache_read``.
+            Callers (e.g. ``TaskWorker``) stamp these onto parent spans so
+            a single trace surfaces the full token bill for a task.
     """
 
     content: list[dict[str, Any]]
     stop_reason: str | None = None
     turns: list[CompletionTurn] = field(default_factory=list)
+    token_usage: dict[str, int] = field(default_factory=lambda: {
+        "input": 0,
+        "output": 0,
+        "cache_creation": 0,
+        "cache_read": 0,
+    })
 
 
 async def run_completion(
@@ -119,6 +129,27 @@ async def run_completion(
     turns: list[CompletionTurn] = []
     cycle_start = time.monotonic()
     metrics = _get_metrics()
+    token_totals: dict[str, int] = {
+        "input": 0,
+        "output": 0,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }
+
+    def _accumulate_usage(response: LLMResponse) -> None:
+        """Fold a single response's token usage into the cycle running totals."""
+        usage = response.usage or {}
+        token_totals["input"] += int(usage.get("input_tokens", 0) or 0)
+        token_totals["output"] += int(usage.get("output_tokens", 0) or 0)
+        token_totals["cache_creation"] += int(usage.get("cache_creation_input_tokens", 0) or 0)
+        token_totals["cache_read"] += int(usage.get("cache_read_input_tokens", 0) or 0)
+
+    def _stamp_tokens(span: Any) -> None:
+        """Set the running token totals as span attributes."""
+        span.set_attribute("completion.input_tokens", token_totals["input"])
+        span.set_attribute("completion.output_tokens", token_totals["output"])
+        span.set_attribute("completion.cache_creation_tokens", token_totals["cache_creation"])
+        span.set_attribute("completion.cache_read_tokens", token_totals["cache_read"])
 
     def _check_cancel() -> None:
         if should_cancel is not None and should_cancel():
@@ -126,6 +157,7 @@ async def run_completion(
                 content=turns[-1].response.content if turns else [],
                 stop_reason="cancelled",
                 turns=turns,
+                token_usage=dict(token_totals),
             )
             raise CancellationRequested("cancellation requested", partial)
 
@@ -133,8 +165,20 @@ async def run_completion(
         while True:
             turn_number = len(turns) + 1
 
-            with otel_span("agentling.completion.llm_call", {"completion.turn": turn_number}):
+            with otel_span("agentling.completion.llm_call", {"completion.turn": turn_number}) as llm_span:
                 response = await llm.complete(system, messages, tool_schemas)
+                _accumulate_usage(response)
+                usage = response.usage or {}
+                llm_span.set_attribute("llm.input_tokens", int(usage.get("input_tokens", 0) or 0))
+                llm_span.set_attribute("llm.output_tokens", int(usage.get("output_tokens", 0) or 0))
+                llm_span.set_attribute(
+                    "llm.cache_read_input_tokens",
+                    int(usage.get("cache_read_input_tokens", 0) or 0),
+                )
+                if response.model:
+                    llm_span.set_attribute("llm.model", response.model)
+                if response.stop_reason:
+                    llm_span.set_attribute("llm.stop_reason", response.stop_reason)
 
             _check_cancel()
 
@@ -155,12 +199,14 @@ async def run_completion(
                 cycle_span.set_attribute("completion.turns", len(turns))
                 cycle_span.set_attribute("completion.stop_reason", response.stop_reason or "unknown")
                 cycle_span.set_attribute("completion.duration_s", round(elapsed, 2))
+                _stamp_tokens(cycle_span)
                 metrics["duration"].record(elapsed)
                 metrics["turns"].record(len(turns))
                 return CompletionResult(
                     content=response.content,
                     stop_reason=response.stop_reason,
                     turns=turns,
+                    token_usage=dict(token_totals),
                 )
 
             messages.append({"role": "assistant", "content": response.content})
@@ -175,19 +221,24 @@ async def run_completion(
             _check_cancel()
 
             async def _exec_tool(block: dict[str, Any]) -> dict[str, Any]:
+                tool_name = block["name"]
+                tool_start = time.monotonic()
                 try:
                     with otel_span("agentling.completion.tool_exec", {
-                        "tool.name": block["name"],
+                        "tool.name": tool_name,
                         "completion.turn": turn_number,
                     }) as tool_span:
-                        result = await tools.execute(block["name"], block.get("input", {}))
+                        result = await tools.execute(tool_name, block.get("input", {}))
+                        duration = time.monotonic() - tool_start
                         tool_span.set_attribute("tool.is_error", result.is_error)
+                        tool_span.set_attribute("tool.duration_seconds", round(duration, 4))
 
-                    tool_attrs = {"tool.name": block["name"]}
+                    tool_attrs = {"tool.name": tool_name}
                     metrics["tool_calls"].add(1, tool_attrs)
+                    record_tool_duration(tool_name, duration, result.is_error)
                     if result.is_error:
                         metrics["tool_errors"].add(1, tool_attrs)
-                        logger.warning("tool %s returned error: %.200s", block["name"], result.output)
+                        logger.warning("tool %s returned error: %.200s", tool_name, result.output)
 
                     return {
                         "type": "tool_result",
@@ -198,13 +249,15 @@ async def run_completion(
                 except asyncio.CancelledError:
                     raise
                 except Exception:
-                    logger.exception("unhandled exception in tool %s", block["name"])
-                    metrics["tool_calls"].add(1, {"tool.name": block["name"]})
-                    metrics["tool_errors"].add(1, {"tool.name": block["name"]})
+                    duration = time.monotonic() - tool_start
+                    logger.exception("unhandled exception in tool %s", tool_name)
+                    metrics["tool_calls"].add(1, {"tool.name": tool_name})
+                    metrics["tool_errors"].add(1, {"tool.name": tool_name})
+                    record_tool_duration(tool_name, duration, True)
                     return {
                         "type": "tool_result",
                         "tool_use_id": block["id"],
-                        "content": f"Tool {block['name']} failed with an internal error",
+                        "content": f"Tool {tool_name} failed with an internal error",
                         "is_error": True,
                     }
 

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Literal
 from uuid import uuid4
+
+from agentlings.core.telemetry import otel_span, record_llm_usage
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +30,17 @@ class LLMResponse:
     Attributes:
         content: List of content blocks (text, tool_use, etc.) from the model.
         stop_reason: Why the model stopped generating (e.g. ``"end_turn"``, ``"tool_use"``).
+        usage: Token-usage dict mirroring Anthropic's response shape —
+            ``input_tokens``, ``output_tokens``, ``cache_creation_input_tokens``,
+            ``cache_read_input_tokens``. Empty for backends that don't report usage.
+        model: The model identifier the call resolved to. Used as a telemetry
+            label so dashboards can slice by model.
     """
 
     content: list[dict[str, Any]]
     stop_reason: str | None = None
+    usage: dict[str, int] = field(default_factory=dict)
+    model: str = ""
 
 
 @dataclass
@@ -232,11 +242,37 @@ class AnthropicLLMClient(BaseLLMClient):
                 }
             }
 
-        response = await self._client.messages.create(**kwargs)
-        return LLMResponse(
-            content=[block.model_dump() for block in response.content],
-            stop_reason=response.stop_reason,
-        )
+        with otel_span("agentling.llm.complete", {
+            "llm.backend": "anthropic",
+            "llm.model": self._model,
+            "llm.max_tokens": self._max_tokens,
+            "llm.message_count": len(messages),
+            "llm.tool_count": len(tools or []),
+            "llm.has_output_schema": bool(output_schema),
+        }) as span:
+            start = time.monotonic()
+            response = await self._client.messages.create(**kwargs)
+            duration = time.monotonic() - start
+
+            usage = _extract_usage(response.usage)
+            usage_total = record_llm_usage(
+                usage,
+                model=self._model,
+                path="live",
+            )
+            span.set_attribute("llm.duration_seconds", round(duration, 4))
+            span.set_attribute("llm.stop_reason", response.stop_reason or "unknown")
+            span.set_attribute("llm.input_tokens", usage_total["input"])
+            span.set_attribute("llm.output_tokens", usage_total["output"])
+            span.set_attribute("llm.cache_creation_input_tokens", usage_total["cache_creation"])
+            span.set_attribute("llm.cache_read_input_tokens", usage_total["cache_read"])
+
+            return LLMResponse(
+                content=[block.model_dump() for block in response.content],
+                stop_reason=response.stop_reason,
+                usage=usage,
+                model=self._model,
+            )
 
     async def stream(
         self,
@@ -248,11 +284,17 @@ class AnthropicLLMClient(BaseLLMClient):
         yield  # pragma: no cover
 
     async def count_tokens(self, text: str) -> int:
-        result = await self._client.messages.count_tokens(
-            model=self._model,
-            messages=[{"role": "user", "content": text}],
-        )
-        return result.input_tokens
+        with otel_span("agentling.llm.count_tokens", {
+            "llm.backend": "anthropic",
+            "llm.model": self._model,
+            "llm.text_chars": len(text),
+        }) as span:
+            result = await self._client.messages.count_tokens(
+                model=self._model,
+                messages=[{"role": "user", "content": text}],
+            )
+            span.set_attribute("llm.input_tokens", int(result.input_tokens))
+            return result.input_tokens
 
     async def batch_create(self, requests: list[BatchRequest], model: str | None = None) -> list[str]:
         from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
@@ -261,64 +303,96 @@ class AnthropicLLMClient(BaseLLMClient):
         use_model = model or self._model
         batch_ids: list[str] = []
 
-        for i in range(0, len(requests), BATCH_MAX_REQUESTS):
-            chunk = requests[i : i + BATCH_MAX_REQUESTS]
-            api_requests = []
-            for req in chunk:
-                params: dict[str, Any] = {
-                    "model": use_model,
-                    "max_tokens": req.max_tokens,
-                    "system": req.system,
-                    "messages": req.messages,
-                }
-                if req.output_schema:
-                    params["output_config"] = {
-                        "format": {
-                            "type": "json_schema",
-                            "schema": req.output_schema,
-                        }
+        with otel_span("agentling.llm.batch_create", {
+            "llm.backend": "anthropic",
+            "llm.model": use_model,
+            "llm.batch.request_count": len(requests),
+        }) as span:
+            for i in range(0, len(requests), BATCH_MAX_REQUESTS):
+                chunk = requests[i : i + BATCH_MAX_REQUESTS]
+                api_requests = []
+                for req in chunk:
+                    params: dict[str, Any] = {
+                        "model": use_model,
+                        "max_tokens": req.max_tokens,
+                        "system": req.system,
+                        "messages": req.messages,
                     }
-                api_requests.append(
-                    Request(
-                        custom_id=req.custom_id,
-                        params=MessageCreateParamsNonStreaming(**params),
+                    if req.output_schema:
+                        params["output_config"] = {
+                            "format": {
+                                "type": "json_schema",
+                                "schema": req.output_schema,
+                            }
+                        }
+                    api_requests.append(
+                        Request(
+                            custom_id=req.custom_id,
+                            params=MessageCreateParamsNonStreaming(**params),
+                        )
                     )
-                )
 
-            result = await self._client.messages.batches.create(requests=api_requests)
-            batch_ids.append(result.id)
-            logger.info("batch submitted: %s (%d requests)", result.id, len(chunk))
+                result = await self._client.messages.batches.create(requests=api_requests)
+                batch_ids.append(result.id)
+                logger.info("batch submitted: %s (%d requests)", result.id, len(chunk))
+
+            span.set_attribute("llm.batch.chunk_count", len(batch_ids))
 
         return batch_ids
 
     async def batch_status(self, batch_id: str) -> BatchStatus:
-        result = await self._client.messages.batches.retrieve(batch_id)
-        counts = result.request_counts
-        return BatchStatus(
-            batch_id=result.id,
-            processing_status=result.processing_status,
-            succeeded=counts.succeeded,
-            failed=counts.errored + counts.expired,
-            total=counts.succeeded + counts.errored + counts.expired + counts.processing,
-        )
+        with otel_span("agentling.llm.batch_status", {
+            "llm.backend": "anthropic",
+            "llm.batch_id": batch_id,
+        }) as span:
+            result = await self._client.messages.batches.retrieve(batch_id)
+            counts = result.request_counts
+            span.set_attribute("llm.batch.processing_status", result.processing_status)
+            span.set_attribute("llm.batch.succeeded", counts.succeeded)
+            span.set_attribute(
+                "llm.batch.failed", counts.errored + counts.expired,
+            )
+            return BatchStatus(
+                batch_id=result.id,
+                processing_status=result.processing_status,
+                succeeded=counts.succeeded,
+                failed=counts.errored + counts.expired,
+                total=counts.succeeded + counts.errored + counts.expired + counts.processing,
+            )
 
     async def batch_results(self, batch_id: str) -> list[BatchItemResult]:
         items: list[BatchItemResult] = []
-        async for entry in await self._client.messages.batches.results(batch_id):
-            if entry.result.type == "succeeded":
-                content = [block.model_dump() for block in entry.result.message.content]
-                items.append(BatchItemResult(
-                    custom_id=entry.custom_id,
-                    content=content,
-                    status="succeeded",
-                ))
-            else:
-                error_msg = str(entry.result.error) if hasattr(entry.result, "error") else "unknown error"
-                items.append(BatchItemResult(
-                    custom_id=entry.custom_id,
-                    status="failed",
-                    error=error_msg,
-                ))
+        # Tests instantiate the client via __new__ to bypass __init__, so
+        # ``_model`` may be unset. Fall back rather than raise.
+        model = getattr(self, "_model", "unknown")
+        with otel_span("agentling.llm.batch_results", {
+            "llm.backend": "anthropic",
+            "llm.batch_id": batch_id,
+        }) as span:
+            succeeded = 0
+            failed = 0
+            async for entry in await self._client.messages.batches.results(batch_id):
+                if entry.result.type == "succeeded":
+                    msg = entry.result.message
+                    content = [block.model_dump() for block in msg.content]
+                    usage = _extract_usage(getattr(msg, "usage", None))
+                    record_llm_usage(usage, model=model, path="batch")
+                    items.append(BatchItemResult(
+                        custom_id=entry.custom_id,
+                        content=content,
+                        status="succeeded",
+                    ))
+                    succeeded += 1
+                else:
+                    error_msg = str(entry.result.error) if hasattr(entry.result, "error") else "unknown error"
+                    items.append(BatchItemResult(
+                        custom_id=entry.custom_id,
+                        status="failed",
+                        error=error_msg,
+                    ))
+                    failed += 1
+            span.set_attribute("llm.batch.succeeded", succeeded)
+            span.set_attribute("llm.batch.failed", failed)
         return items
 
 
@@ -334,6 +408,8 @@ class MockLLMClient(BaseLLMClient):
     answer"``). The mock sleeps that many seconds before responding. The
     delay is skipped on tool-result loops so multi-turn flows don't re-sleep.
     """
+
+    MOCK_MODEL = "mock-model"
 
     def __init__(
         self,
@@ -372,28 +448,48 @@ class MockLLMClient(BaseLLMClient):
             if m:
                 await asyncio.sleep(float(m.group(1)))
 
-        if last_message.get("role") == "tool":
-            return LLMResponse(
-                content=[{"type": "text", "text": f"Tool result received: {last_text}"}],
-                stop_reason="end_turn",
-            )
-
-        for tool_name in self._tool_names:
-            if tool_name in last_text:
-                return LLMResponse(
-                    content=[{
-                        "type": "tool_use",
-                        "id": f"toolu_{uuid4().hex[:12]}",
-                        "name": tool_name,
-                        "input": _build_mock_tool_input(tool_name, last_text),
-                    }],
-                    stop_reason="tool_use",
+        with otel_span("agentling.llm.complete", {
+            "llm.backend": "mock",
+            "llm.model": self.MOCK_MODEL,
+            "llm.message_count": len(messages),
+            "llm.tool_count": len(tools or []),
+        }) as span:
+            if last_message.get("role") == "tool":
+                response = LLMResponse(
+                    content=[{"type": "text", "text": f"Tool result received: {last_text}"}],
+                    stop_reason="end_turn",
+                    model=self.MOCK_MODEL,
                 )
+            else:
+                response = None
+                for tool_name in self._tool_names:
+                    if tool_name in last_text:
+                        response = LLMResponse(
+                            content=[{
+                                "type": "tool_use",
+                                "id": f"toolu_{uuid4().hex[:12]}",
+                                "name": tool_name,
+                                "input": _build_mock_tool_input(tool_name, last_text),
+                            }],
+                            stop_reason="tool_use",
+                            model=self.MOCK_MODEL,
+                        )
+                        break
 
-        return LLMResponse(
-            content=[{"type": "text", "text": f"Mock response to: {last_text}"}],
-            stop_reason="end_turn",
-        )
+                if response is None:
+                    response = LLMResponse(
+                        content=[{"type": "text", "text": f"Mock response to: {last_text}"}],
+                        stop_reason="end_turn",
+                        model=self.MOCK_MODEL,
+                    )
+
+            usage = _synthesize_mock_usage(messages, response.content)
+            response.usage = usage
+            usage_total = record_llm_usage(usage, model=self.MOCK_MODEL, path="live")
+            span.set_attribute("llm.stop_reason", response.stop_reason or "unknown")
+            span.set_attribute("llm.input_tokens", usage_total["input"])
+            span.set_attribute("llm.output_tokens", usage_total["output"])
+            return response
 
     async def stream(
         self,
@@ -433,9 +529,12 @@ class MockLLMClient(BaseLLMClient):
                 "summary": f"Summary of conversation: {text[:100]}",
                 "memory_candidates": [],
             }
+            response_content = [{"type": "text", "text": json.dumps(mock_output)}]
+            usage = _synthesize_mock_usage(req.messages, response_content)
+            record_llm_usage(usage, model=self.MOCK_MODEL, path="batch")
             results.append(BatchItemResult(
                 custom_id=req.custom_id,
-                content=[{"type": "text", "text": json.dumps(mock_output)}],
+                content=response_content,
                 status="succeeded",
             ))
         return results
@@ -476,6 +575,65 @@ def create_llm_client(
     return AnthropicLLMClient(
         api_key=api_key, model=model, max_tokens=max_tokens, base_url=base_url,
     )
+
+
+def _extract_usage(usage: Any) -> dict[str, int]:
+    """Normalise an Anthropic ``Usage`` object into a plain dict.
+
+    Anthropic-compatible backends (e.g. Ollama) may omit cache fields, so
+    treat every field as optional and default to zero.
+    """
+    if usage is None:
+        return {}
+    if isinstance(usage, dict):
+        src = usage
+    else:
+        src = {
+            k: getattr(usage, k, 0)
+            for k in (
+                "input_tokens",
+                "output_tokens",
+                "cache_creation_input_tokens",
+                "cache_read_input_tokens",
+            )
+        }
+    return {
+        "input_tokens": int(src.get("input_tokens", 0) or 0),
+        "output_tokens": int(src.get("output_tokens", 0) or 0),
+        "cache_creation_input_tokens": int(
+            src.get("cache_creation_input_tokens", 0) or 0
+        ),
+        "cache_read_input_tokens": int(
+            src.get("cache_read_input_tokens", 0) or 0
+        ),
+    }
+
+
+def _synthesize_mock_usage(
+    messages: list[dict[str, Any]],
+    response_content: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Approximate token counts for the mock backend.
+
+    Uses ``len(text) // 4`` — the same heuristic ``MockLLMClient.count_tokens``
+    has always used. This lets tests reason about non-zero token telemetry
+    without coupling them to a real LLM.
+    """
+    input_chars = 0
+    for msg in messages:
+        input_chars += len(_extract_text(msg))
+
+    output_chars = 0
+    for block in response_content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            output_chars += len(block.get("text", ""))
+
+    return {
+        "input_tokens": max(input_chars // 4, 1),
+        "output_tokens": max(output_chars // 4, 1),
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
 
 
 def _extract_text(message: dict[str, Any]) -> str:

--- a/src/agentlings/core/store.py
+++ b/src/agentlings/core/store.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import time
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -26,6 +27,10 @@ from agentlings.core.models import (
     TaskCancelled,
     TaskDispatched,
     TaskFailed,
+)
+from agentlings.core.telemetry import (
+    record_journal_append,
+    record_journal_replay,
 )
 
 logger = logging.getLogger(__name__)
@@ -155,7 +160,14 @@ class JournalStore:
         if not path.exists():
             raise ContextNotFoundError(ctx_id)
 
-        _append_jsonl(path, entry.model_dump_json() + "\n")
+        line = entry.model_dump_json() + "\n"
+        start = time.monotonic()
+        _append_jsonl(path, line)
+        record_journal_append(
+            target="parent",
+            byte_count=len(line.encode("utf-8")),
+            duration_seconds=time.monotonic() - start,
+        )
         logger.debug("appended %s entry to context %s", entry.t, ctx_id)
 
     def append_many(self, ctx_id: str, entries: Iterable[ParentJournalEntry]) -> None:
@@ -179,6 +191,8 @@ class JournalStore:
         lines = [e.model_dump_json() + "\n" for e in entries]
         if not lines:
             return
+        byte_count = sum(len(line.encode("utf-8")) for line in lines)
+        start = time.monotonic()
         with open(path, "a", encoding="utf-8") as f:
             fcntl.flock(f, fcntl.LOCK_EX)
             try:
@@ -186,6 +200,11 @@ class JournalStore:
                 f.flush()
             finally:
                 fcntl.flock(f, fcntl.LOCK_UN)
+        record_journal_append(
+            target="parent",
+            byte_count=byte_count,
+            duration_seconds=time.monotonic() - start,
+        )
 
     def read_entries(self, ctx_id: str) -> list[dict[str, Any]]:
         """Return every parsed journal entry for a context in insertion order.
@@ -216,8 +235,14 @@ class JournalStore:
         Raises:
             ContextNotFoundError: If no journal file exists for the context.
         """
+        start = time.monotonic()
         parsed = self.read_entries(ctx_id)
         if not parsed:
+            record_journal_replay(
+                target="parent",
+                entry_count=0,
+                duration_seconds=time.monotonic() - start,
+            )
             return []
 
         cursor = 0
@@ -241,6 +266,11 @@ class JournalStore:
                     "role": entry["role"],
                     "content": entry["content"],
                 })
+        record_journal_replay(
+            target="parent",
+            entry_count=len(messages),
+            duration_seconds=time.monotonic() - start,
+        )
         return messages
 
     def iter_context_ids(self) -> list[str]:
@@ -289,7 +319,14 @@ class TaskJournal:
         """Append an entry (any Pydantic ``BaseModel`` with ``model_dump_json``)."""
         if not self._path.exists():
             self.create()
-        _append_jsonl(self._path, entry.model_dump_json() + "\n")
+        line = entry.model_dump_json() + "\n"
+        start = time.monotonic()
+        _append_jsonl(self._path, line)
+        record_journal_append(
+            target="sub",
+            byte_count=len(line.encode("utf-8")),
+            duration_seconds=time.monotonic() - start,
+        )
 
     def read_entries(self) -> list[dict[str, Any]]:
         """Return all parsed entries in insertion order."""

--- a/src/agentlings/core/task.py
+++ b/src/agentlings/core/task.py
@@ -44,7 +44,12 @@ from agentlings.core.models import (
 from agentlings.core.prompt import build_system_prompt
 from agentlings.core.skills import SkillRef
 from agentlings.core.store import JournalStore, TaskJournal
-from agentlings.core.telemetry import get_meter, otel_span
+from agentlings.core.telemetry import (
+    attach_context,
+    capture_context,
+    get_meter,
+    otel_span,
+)
 from agentlings.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -353,6 +358,7 @@ class TaskWorker:
         context_lock: asyncio.Lock,
         memory_store: MemoryFileStore | None = None,
         skills: list[SkillRef] | None = None,
+        otel_parent_context: Any = None,
     ) -> None:
         self._record = record
         self._config = config
@@ -364,23 +370,34 @@ class TaskWorker:
         self._context_lock = context_lock
         self._memory_store = memory_store
         self._skills = skills or []
+        self._otel_parent_context = otel_parent_context
+        self._completion_result: CompletionResult | None = None
 
     async def run(self) -> None:
         """Drive the task to a terminal state.
 
         The worker writes exactly one terminal sub-journal entry before
         returning, regardless of success, failure, or cancellation.
+
+        The worker span is attached to the OTel context captured at
+        ``engine.spawn`` time so traces stitch through the
+        request-handler → engine → worker → completion → llm boundary.
         """
         record = self._record
-        with otel_span("agentling.task.worker", {
+        with attach_context(self._otel_parent_context), otel_span("agentling.task.worker", {
             "task.id": record.task_id,
             "task.context_id": record.context_id,
             "task.via": record.via,
         }) as span:
             try:
                 await self._run_inner()
-            except CancellationRequested:
+                span.set_attribute("task.terminal", "completed")
+                if self._completion_result is not None:
+                    self._stamp_tokens(span, self._completion_result.token_usage)
+            except CancellationRequested as cancelled:
                 span.set_attribute("task.terminal", "cancelled")
+                if cancelled.partial is not None:
+                    self._stamp_tokens(span, cancelled.partial.token_usage)
                 cancel = TaskCancelled(
                     ctx=record.context_id,
                     task_id=record.task_id,
@@ -498,6 +515,9 @@ class TaskWorker:
             turn_callback=_on_turn,
             should_cancel=lambda: record.cancel_flag,
         )
+        # Stash so ``run`` can stamp the cycle's token totals onto the
+        # worker span before exiting.
+        self._completion_result = result
 
         self._journal.append(TaskCompleted(
             ctx=record.context_id,
@@ -507,6 +527,14 @@ class TaskWorker:
 
         await self._merge_back(result)
         record.status = TaskStatus.COMPLETED
+
+    @staticmethod
+    def _stamp_tokens(span: Any, totals: dict[str, int]) -> None:
+        """Stamp token totals onto the worker span (cheap when telemetry off)."""
+        span.set_attribute("task.input_tokens", int(totals.get("input", 0)))
+        span.set_attribute("task.output_tokens", int(totals.get("output", 0)))
+        span.set_attribute("task.cache_creation_tokens", int(totals.get("cache_creation", 0)))
+        span.set_attribute("task.cache_read_tokens", int(totals.get("cache_read", 0)))
 
     async def _merge_back(self, result: CompletionResult) -> None:
         """Atomically propagate the task's outcome to the parent journal.
@@ -652,74 +680,89 @@ class TaskEngine:
             raise InvalidTaskInputError("message must not be empty")
 
         ctx_id = context_id or str(uuid4())
-        if not self._store.exists(ctx_id):
-            self._store.create(ctx_id)
-            logger.info(
-                "context created",
-                extra={"context_id": ctx_id, "via": via},
-            )
-
         task_id = task_id or str(uuid4())
 
-        try:
-            record = self._registry.register(
-                task_id=task_id,
-                context_id=ctx_id,
-                message=message,
-                via=via,
-                owner=owner,
-            )
-        except ContextBusyError:
-            _METRICS.context_busy_rejections.add(1)
-            raise
-
-        self._store.append(ctx_id, TaskDispatched(ctx=ctx_id, task_id=task_id))
-
-        task_journal = TaskJournal(self._store.task_path(ctx_id, task_id))
-        task_journal.create()
-        task_journal.append(TaskStarted(
-            ctx=ctx_id,
-            task_id=task_id,
-            message=message,
-            via=via,  # type: ignore[arg-type]
-        ))
-
-        ctx_lock = await self._lock_for(ctx_id)
-        worker = TaskWorker(
-            record=record,
-            config=self._config,
-            llm=self._llm,
-            tools=self._tools,
-            store=self._store,
-            task_journal=task_journal,
-            registry=self._registry,
-            context_lock=ctx_lock,
-            memory_store=self._memory_store,
-            skills=self._skills,
-        )
-        asyncio_task = asyncio.create_task(worker.run(), name=f"task:{task_id}")
-        self._workers[task_id] = asyncio_task
-        asyncio_task.add_done_callback(
-            lambda _t: self._on_worker_done(task_id, ctx_id)
-        )
-
-        _METRICS.tasks_spawned.add(1)
-        _METRICS.tasks_active.add(1)
-        logger.info(
-            "task spawned",
-            extra={"task_id": task_id, "context_id": ctx_id, "via": via},
-        )
-
-        try:
-            if await_seconds > 0:
-                await asyncio.wait_for(
-                    record.completion_event.wait(),
-                    timeout=await_seconds,
+        with otel_span("agentling.engine.spawn", {
+            "task.id": task_id,
+            "task.context_id": ctx_id,
+            "task.via": via,
+            "task.await_seconds": await_seconds,
+        }) as span:
+            if not self._store.exists(ctx_id):
+                self._store.create(ctx_id)
+                logger.info(
+                    "context created",
+                    extra={"context_id": ctx_id, "via": via},
                 )
-        except asyncio.TimeoutError:
-            pass
 
-        return self._state_from_task(task_id, ctx_id, record, task_journal)
+            try:
+                record = self._registry.register(
+                    task_id=task_id,
+                    context_id=ctx_id,
+                    message=message,
+                    via=via,
+                    owner=owner,
+                )
+            except ContextBusyError:
+                _METRICS.context_busy_rejections.add(1)
+                span.set_attribute("task.outcome", "context_busy")
+                raise
+
+            self._store.append(ctx_id, TaskDispatched(ctx=ctx_id, task_id=task_id))
+
+            task_journal = TaskJournal(self._store.task_path(ctx_id, task_id))
+            task_journal.create()
+            task_journal.append(TaskStarted(
+                ctx=ctx_id,
+                task_id=task_id,
+                message=message,
+                via=via,  # type: ignore[arg-type]
+            ))
+
+            ctx_lock = await self._lock_for(ctx_id)
+            # Capture the calling OTel context here so the worker — which
+            # runs in a fresh ``asyncio.create_task`` and would otherwise
+            # have no parent span — re-attaches it before opening its
+            # own span tree.
+            parent_ctx = capture_context()
+            worker = TaskWorker(
+                record=record,
+                config=self._config,
+                llm=self._llm,
+                tools=self._tools,
+                store=self._store,
+                task_journal=task_journal,
+                registry=self._registry,
+                context_lock=ctx_lock,
+                memory_store=self._memory_store,
+                skills=self._skills,
+                otel_parent_context=parent_ctx,
+            )
+            asyncio_task = asyncio.create_task(worker.run(), name=f"task:{task_id}")
+            self._workers[task_id] = asyncio_task
+            asyncio_task.add_done_callback(
+                lambda _t: self._on_worker_done(task_id, ctx_id)
+            )
+
+            _METRICS.tasks_spawned.add(1)
+            _METRICS.tasks_active.add(1)
+            logger.info(
+                "task spawned",
+                extra={"task_id": task_id, "context_id": ctx_id, "via": via},
+            )
+
+            try:
+                if await_seconds > 0:
+                    await asyncio.wait_for(
+                        record.completion_event.wait(),
+                        timeout=await_seconds,
+                    )
+            except asyncio.TimeoutError:
+                pass
+
+            state = self._state_from_task(task_id, ctx_id, record, task_journal)
+            span.set_attribute("task.status", state.status.value)
+            return state
 
     async def poll(
         self,
@@ -742,40 +785,47 @@ class TaskEngine:
             TaskNotFoundError: If no sub-journal and no registry entry exist.
             TaskContextMismatchError: If the assertion doesn't match.
         """
-        record = self._registry.get(task_id)
-        resolved_ctx = context_id or (record.context_id if record else None)
+        with otel_span("agentling.engine.poll", {
+            "task.id": task_id,
+            "task.context_id": context_id or "",
+            "task.wait_seconds": wait_seconds,
+        }) as span:
+            record = self._registry.get(task_id)
+            resolved_ctx = context_id or (record.context_id if record else None)
 
-        if resolved_ctx is None:
-            found = self._locate_task_context(task_id)
-            if found is None:
+            if resolved_ctx is None:
+                found = self._locate_task_context(task_id)
+                if found is None:
+                    raise TaskNotFoundError(
+                        task_id,
+                        searched="registry+filesystem",
+                    )
+                resolved_ctx = found
+
+            if context_id is not None and record is not None and context_id != record.context_id:
+                raise TaskContextMismatchError(task_id, context_id, record.context_id)
+
+            task_journal = TaskJournal(self._store.task_path(resolved_ctx, task_id))
+            if not task_journal.exists() and record is None:
                 raise TaskNotFoundError(
                     task_id,
-                    searched="registry+filesystem",
+                    searched=f"context={resolved_ctx}",
                 )
-            resolved_ctx = found
 
-        if context_id is not None and record is not None and context_id != record.context_id:
-            raise TaskContextMismatchError(task_id, context_id, record.context_id)
+            if wait_seconds > 0 and record is not None:
+                effective = min(wait_seconds, cap_seconds)
+                try:
+                    await asyncio.wait_for(
+                        record.completion_event.wait(),
+                        timeout=effective,
+                    )
+                except asyncio.TimeoutError:
+                    pass
 
-        task_journal = TaskJournal(self._store.task_path(resolved_ctx, task_id))
-        if not task_journal.exists() and record is None:
-            raise TaskNotFoundError(
-                task_id,
-                searched=f"context={resolved_ctx}",
-            )
-
-        if wait_seconds > 0 and record is not None:
-            effective = min(wait_seconds, cap_seconds)
-            try:
-                await asyncio.wait_for(
-                    record.completion_event.wait(),
-                    timeout=effective,
-                )
-            except asyncio.TimeoutError:
-                pass
-
-        record = self._registry.get(task_id) or record
-        return self._state_from_task(task_id, resolved_ctx, record, task_journal)
+            record = self._registry.get(task_id) or record
+            state = self._state_from_task(task_id, resolved_ctx, record, task_journal)
+            span.set_attribute("task.status", state.status.value)
+            return state
 
     async def cancel(
         self,
@@ -788,28 +838,38 @@ class TaskEngine:
         If the task is active, flips the cancel flag (the worker observes it
         at its next checkpoint and writes the cancel markers).
         """
-        record = self._registry.get(task_id)
-        if record is None:
-            resolved_ctx = context_id or self._locate_task_context(task_id)
-            if resolved_ctx is None:
-                raise TaskNotFoundError(
-                    task_id,
-                    searched="registry+filesystem",
-                )
-            tj = TaskJournal(self._store.task_path(resolved_ctx, task_id))
-            if not tj.exists():
-                raise TaskNotFoundError(
-                    task_id,
-                    searched=f"context={resolved_ctx}",
-                )
-            return self._state_from_task(task_id, resolved_ctx, None, tj)
+        with otel_span("agentling.engine.cancel", {
+            "task.id": task_id,
+            "task.context_id": context_id or "",
+        }) as span:
+            record = self._registry.get(task_id)
+            if record is None:
+                resolved_ctx = context_id or self._locate_task_context(task_id)
+                if resolved_ctx is None:
+                    raise TaskNotFoundError(
+                        task_id,
+                        searched="registry+filesystem",
+                    )
+                tj = TaskJournal(self._store.task_path(resolved_ctx, task_id))
+                if not tj.exists():
+                    raise TaskNotFoundError(
+                        task_id,
+                        searched=f"context={resolved_ctx}",
+                    )
+                state = self._state_from_task(task_id, resolved_ctx, None, tj)
+                span.set_attribute("task.cancel_outcome", "already_terminal")
+                span.set_attribute("task.status", state.status.value)
+                return state
 
-        if context_id is not None and context_id != record.context_id:
-            raise TaskContextMismatchError(task_id, context_id, record.context_id)
+            if context_id is not None and context_id != record.context_id:
+                raise TaskContextMismatchError(task_id, context_id, record.context_id)
 
-        self._registry.request_cancel(task_id)
-        tj = TaskJournal(self._store.task_path(record.context_id, task_id))
-        return self._state_from_task(task_id, record.context_id, record, tj)
+            self._registry.request_cancel(task_id)
+            tj = TaskJournal(self._store.task_path(record.context_id, task_id))
+            state = self._state_from_task(task_id, record.context_id, record, tj)
+            span.set_attribute("task.cancel_outcome", "requested")
+            span.set_attribute("task.status", state.status.value)
+            return state
 
     # ------------------------------------------------------------------ #
     # Internal helpers
@@ -942,8 +1002,9 @@ class TaskEngine:
            unusual — sub-journal might have been purged). Close the wrapper
            with ``MergeCommitted`` alone, no conversational content.
         """
-        self._recover_orphaned_subjournals()
-        self._recover_incomplete_merges()
+        with otel_span("agentling.engine.recovery"):
+            self._recover_orphaned_subjournals()
+            self._recover_incomplete_merges()
 
     def _recover_orphaned_subjournals(self) -> None:
         for sub_path in self._store.data_dir.glob("*/tasks/*.jsonl"):

--- a/src/agentlings/core/telemetry.py
+++ b/src/agentlings/core/telemetry.py
@@ -1,10 +1,35 @@
-"""OpenTelemetry setup and instrumentation for the agent lifecycle."""
+"""OpenTelemetry setup, helpers, and shared instrument cache.
+
+Public surface used across the codebase:
+
+- ``init_telemetry(config)`` — wire OTLP exporters from ``TelemetryConfig``.
+  No-op when ``config.enabled`` is ``False`` or the OTel SDK is missing.
+- ``otel_span(name, attributes)`` — context-managed span; safe when telemetry
+  is disabled (returns a no-op span).
+- ``get_tracer()`` / ``get_meter()`` — public accessors. Both return real
+  OTel objects when initialized, no-op shims otherwise.
+- ``record_llm_usage(usage, *, model, agent_name, path)`` — emit the full
+  token telemetry surface (input, output, cache_creation, cache_read,
+  total, hit-ratio) as histograms + monotonic counters with consistent
+  labels. Returns the totals so callers can stamp them on parent spans.
+- ``record_tool_duration(name, duration_seconds, is_error)`` — per-tool
+  latency histogram.
+- ``record_journal_append(target, byte_count, duration_seconds)`` and
+  ``record_journal_replay(target, entry_count, duration_seconds)`` —
+  journal I/O instrumentation.
+- ``capture_context()`` / ``attach_context(ctx)`` — capture the current
+  OTel context at one ``await`` point and re-attach it at another (used
+  to make the task worker span a descendant of the inbound request span).
+
+All entry points are safe when telemetry is disabled — they emit through
+no-op shims so the only cost is a function call.
+"""
 
 from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any, Generator, Iterator
 
 from agentlings.config import TelemetryConfig
 
@@ -13,6 +38,7 @@ logger = logging.getLogger(__name__)
 _tracer: Any = None
 _meter: Any = None
 _initialized = False
+_instruments: dict[str, Any] = {}
 
 
 def init_telemetry(config: TelemetryConfig) -> None:
@@ -80,6 +106,7 @@ def init_telemetry(config: TelemetryConfig) -> None:
         _tracer = trace.get_tracer("agentling")
         _meter = metrics.get_meter("agentling")
         _initialized = True
+        _instruments.clear()
 
         logger.info(
             "telemetry initialized: endpoint=%s, protocol=%s",
@@ -123,7 +150,7 @@ def otel_span(name: str, attributes: dict[str, Any] | None = None) -> Generator[
     """Context manager that creates a traced span.
 
     Args:
-        name: Span name (e.g. ``"agentling.loop.process_message"``).
+        name: Span name (e.g. ``"agentling.completion"``).
         attributes: Span attributes to set on creation.
 
     Yields:
@@ -138,6 +165,268 @@ def otel_span(name: str, attributes: dict[str, Any] | None = None) -> Generator[
 
 
 sleep_span = otel_span
+
+
+# --------------------------------------------------------------------------- #
+# Context propagation across asyncio.create_task boundaries
+# --------------------------------------------------------------------------- #
+
+
+def capture_context() -> Any:
+    """Capture the current OTel context.
+
+    Returned object is opaque; pass it to ``attach_context`` from the
+    target async task to make spans created there descendants of the
+    captured span.
+
+    Returns ``None`` (cheaply) when the OTel API is not importable, which
+    keeps no-op deployments lean.
+    """
+    try:
+        from opentelemetry import context as otel_context
+        return otel_context.get_current()
+    except ImportError:
+        return None
+
+
+@contextmanager
+def attach_context(ctx: Any) -> Iterator[None]:
+    """Re-attach a previously captured OTel context for the duration of the block.
+
+    Used inside ``asyncio.create_task`` callbacks where the parent context
+    would otherwise be lost. Pairs with ``capture_context``.
+    """
+    if ctx is None:
+        yield
+        return
+    try:
+        from opentelemetry import context as otel_context
+    except ImportError:
+        yield
+        return
+    token = otel_context.attach(ctx)
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
+
+
+# --------------------------------------------------------------------------- #
+# Shared instrument cache + recording helpers
+# --------------------------------------------------------------------------- #
+
+
+def _get_instrument(key: str, factory: Any) -> Any:
+    """Return a cached metric instrument, creating it on first access."""
+    inst = _instruments.get(key)
+    if inst is not None:
+        return inst
+    inst = factory()
+    _instruments[key] = inst
+    return inst
+
+
+def _llm_token_instruments() -> dict[str, Any]:
+    """Lazily build the LLM token histograms + counters."""
+    m = get_meter()
+
+    def _build() -> dict[str, Any]:
+        return {
+            # Histograms — useful for percentiles and per-call distribution.
+            "input_h": m.create_histogram(
+                "agentling.llm.input_tokens",
+                description="Fresh prompt tokens charged on an LLM call.",
+            ),
+            "output_h": m.create_histogram(
+                "agentling.llm.output_tokens",
+                description="Generated output tokens on an LLM call.",
+            ),
+            "cache_creation_h": m.create_histogram(
+                "agentling.llm.cache_creation_input_tokens",
+                description="Tokens written to the prompt cache.",
+            ),
+            "cache_read_h": m.create_histogram(
+                "agentling.llm.cache_read_input_tokens",
+                description="Tokens served from the prompt cache.",
+            ),
+            "total_h": m.create_histogram(
+                "agentling.llm.total_tokens",
+                description="Sum of input + output + cache tokens.",
+            ),
+            "hit_ratio_h": m.create_histogram(
+                "agentling.llm.cache_hit_ratio",
+                description="cache_read / (input + cache_read) per call.",
+            ),
+            # Monotonic counters — better for rate() queries.
+            "input_c": m.create_counter(
+                "agentling.llm.input_tokens_total",
+                description="Cumulative fresh prompt tokens.",
+            ),
+            "output_c": m.create_counter(
+                "agentling.llm.output_tokens_total",
+                description="Cumulative output tokens.",
+            ),
+            "cache_creation_c": m.create_counter(
+                "agentling.llm.cache_creation_input_tokens_total",
+                description="Cumulative cache-write tokens.",
+            ),
+            "cache_read_c": m.create_counter(
+                "agentling.llm.cache_read_input_tokens_total",
+                description="Cumulative cache-read tokens.",
+            ),
+            "calls_c": m.create_counter(
+                "agentling.llm.calls_total",
+                description="Cumulative LLM call count.",
+            ),
+        }
+
+    return _get_instrument("llm.tokens", _build)
+
+
+def record_llm_usage(
+    usage: dict[str, Any] | None,
+    *,
+    model: str,
+    agent_name: str = "",
+    path: str = "live",
+) -> dict[str, int]:
+    """Emit the full LLM token telemetry surface for a single call.
+
+    Args:
+        usage: Anthropic-style ``usage`` dict carrying ``input_tokens``,
+            ``output_tokens``, ``cache_creation_input_tokens``,
+            ``cache_read_input_tokens``. ``None`` records a single call
+            event with zero tokens (useful for non-Anthropic backends).
+        model: Model identifier — labels every metric for slicing.
+        agent_name: Agent name from config (optional label).
+        path: ``"live"`` for ``messages.create`` calls, ``"batch"`` for
+            results coming out of the batch API. Lets dashboards filter
+            interactive vs. nightly token spend.
+
+    Returns:
+        Dict with the four token counts: ``input``, ``output``,
+        ``cache_creation``, ``cache_read``. Callers roll these up onto
+        parent spans for at-a-glance trace inspection.
+    """
+    inst = _llm_token_instruments()
+    attrs = {"llm.model": model, "llm.path": path}
+    if agent_name:
+        attrs["agent.name"] = agent_name
+
+    u = usage or {}
+    input_tokens = int(u.get("input_tokens", 0) or 0)
+    output_tokens = int(u.get("output_tokens", 0) or 0)
+    cache_creation = int(u.get("cache_creation_input_tokens", 0) or 0)
+    cache_read = int(u.get("cache_read_input_tokens", 0) or 0)
+    total = input_tokens + output_tokens + cache_creation + cache_read
+
+    inst["calls_c"].add(1, attrs)
+
+    if input_tokens:
+        inst["input_h"].record(input_tokens, attrs)
+        inst["input_c"].add(input_tokens, attrs)
+    if output_tokens:
+        inst["output_h"].record(output_tokens, attrs)
+        inst["output_c"].add(output_tokens, attrs)
+    if cache_creation:
+        inst["cache_creation_h"].record(cache_creation, attrs)
+        inst["cache_creation_c"].add(cache_creation, attrs)
+    if cache_read:
+        inst["cache_read_h"].record(cache_read, attrs)
+        inst["cache_read_c"].add(cache_read, attrs)
+    if total:
+        inst["total_h"].record(total, attrs)
+    # Cache hit ratio — only meaningful when there's *some* prompt input
+    # (fresh + cached). Reporting 0 when there's no input would skew the
+    # distribution.
+    denom = input_tokens + cache_read
+    if denom:
+        inst["hit_ratio_h"].record(cache_read / denom, attrs)
+
+    return {
+        "input": input_tokens,
+        "output": output_tokens,
+        "cache_creation": cache_creation,
+        "cache_read": cache_read,
+    }
+
+
+def _tool_instruments() -> dict[str, Any]:
+    m = get_meter()
+
+    def _build() -> dict[str, Any]:
+        return {
+            "duration": m.create_histogram(
+                "agentling.tool.duration_seconds",
+                description="Tool execution wall-clock duration.",
+            ),
+        }
+
+    return _get_instrument("tool", _build)
+
+
+def record_tool_duration(name: str, duration_seconds: float, is_error: bool) -> None:
+    """Record a tool-execution latency sample with name + error labels."""
+    inst = _tool_instruments()
+    inst["duration"].record(
+        duration_seconds,
+        {"tool.name": name, "tool.is_error": str(is_error).lower()},
+    )
+
+
+def _journal_instruments() -> dict[str, Any]:
+    m = get_meter()
+
+    def _build() -> dict[str, Any]:
+        return {
+            "append_seconds": m.create_histogram(
+                "agentling.journal.append_seconds",
+                description="JSONL append wall-clock duration.",
+            ),
+            "replay_seconds": m.create_histogram(
+                "agentling.journal.replay_seconds",
+                description="Journal replay wall-clock duration.",
+            ),
+            "entries_replayed": m.create_counter(
+                "agentling.journal.entries_replayed_total",
+                description="Cumulative count of journal entries replayed.",
+            ),
+            "bytes_appended": m.create_counter(
+                "agentling.journal.bytes_appended_total",
+                description="Cumulative bytes appended to JSONL journals.",
+            ),
+        }
+
+    return _get_instrument("journal", _build)
+
+
+def record_journal_append(target: str, byte_count: int, duration_seconds: float) -> None:
+    """Record an append latency sample and bump the bytes-written counter.
+
+    Args:
+        target: ``"parent"`` or ``"sub"`` — which journal layer was hit.
+        byte_count: Bytes written in this append.
+        duration_seconds: Wall-clock duration of the append.
+    """
+    inst = _journal_instruments()
+    attrs = {"journal.target": target}
+    inst["append_seconds"].record(duration_seconds, attrs)
+    if byte_count:
+        inst["bytes_appended"].add(byte_count, attrs)
+
+
+def record_journal_replay(target: str, entry_count: int, duration_seconds: float) -> None:
+    """Record a replay latency sample and bump the entries-replayed counter."""
+    inst = _journal_instruments()
+    attrs = {"journal.target": target}
+    inst["replay_seconds"].record(duration_seconds, attrs)
+    if entry_count:
+        inst["entries_replayed"].add(entry_count, attrs)
+
+
+# --------------------------------------------------------------------------- #
+# No-op fallbacks
+# --------------------------------------------------------------------------- #
 
 
 class _NoOpSpan:

--- a/src/agentlings/protocol/a2a.py
+++ b/src/agentlings/protocol/a2a.py
@@ -34,6 +34,7 @@ from agentlings.core.task import (
     TaskState,
     TaskStatus,
 )
+from agentlings.core.telemetry import otel_span
 from agentlings.protocol.a2a_task_store import task_state_to_a2a_task
 
 logger = logging.getLogger(__name__)
@@ -99,57 +100,70 @@ class AgentlingExecutor(AgentExecutor):
             (user_text or "")[:100],
         )
 
-        try:
-            state = await self._engine.spawn(
-                message=user_text,
-                context_id=context_id,
-                via="a2a",
-                await_seconds=await_seconds,
-                task_id=sdk_task_id,
-            )
-        except ContextBusyError as e:
-            # Surface as a plain agent message — there is no live Task on this
-            # context that the caller can latch onto (it's someone else's).
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    _format_busy(e),
+        with otel_span("agentling.a2a.execute", {
+            "agent.via": "a2a",
+            "task.context_id": context_id or "",
+            "task.id": sdk_task_id or "",
+            "a2a.return_immediately": return_immediately,
+            "a2a.message_chars": len(user_text or ""),
+        }) as span:
+            try:
+                state = await self._engine.spawn(
+                    message=user_text,
                     context_id=context_id,
+                    via="a2a",
+                    await_seconds=await_seconds,
+                    task_id=sdk_task_id,
                 )
+            except ContextBusyError as e:
+                # Surface as a plain agent message — there is no live Task on this
+                # context that the caller can latch onto (it's someone else's).
+                span.set_attribute("a2a.outcome", "context_busy")
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        _format_busy(e),
+                        context_id=context_id,
+                    )
+                )
+                await event_queue.close()
+                return
+            except Exception:  # noqa: BLE001
+                span.set_attribute("a2a.outcome", "exception")
+                logger.exception("error processing A2A message")
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        "Internal error processing request.",
+                        context_id=context_id,
+                    )
+                )
+                await event_queue.close()
+                return
+
+            span.set_attribute("task.status", state.status.value)
+
+            if state.status == TaskStatus.COMPLETED:
+                span.set_attribute("a2a.outcome", "completed")
+                # Fast path — return the final response text as a Message event.
+                response_text = _extract_text(state.content)
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        response_text,
+                        context_id=state.context_id,
+                        task_id=state.task_id,
+                    )
+                )
+            else:
+                span.set_attribute("a2a.outcome", "task_handle")
+                # Slow path or terminal-with-error — enqueue a native A2A Task so
+                # the client's GetTask/CancelTask flows reach our engine.
+                a2a_task = task_state_to_a2a_task(state)
+                await event_queue.enqueue_event(a2a_task)
+
+            logger.debug(
+                "a2a response: context_id=%s status=%s task_id=%s",
+                state.context_id, state.status.value, state.task_id,
             )
             await event_queue.close()
-            return
-        except Exception:  # noqa: BLE001
-            logger.exception("error processing A2A message")
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    "Internal error processing request.",
-                    context_id=context_id,
-                )
-            )
-            await event_queue.close()
-            return
-
-        if state.status == TaskStatus.COMPLETED:
-            # Fast path — return the final response text as a Message event.
-            response_text = _extract_text(state.content)
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    response_text,
-                    context_id=state.context_id,
-                    task_id=state.task_id,
-                )
-            )
-        else:
-            # Slow path or terminal-with-error — enqueue a native A2A Task so
-            # the client's GetTask/CancelTask flows reach our engine.
-            a2a_task = task_state_to_a2a_task(state)
-            await event_queue.enqueue_event(a2a_task)
-
-        logger.debug(
-            "a2a response: context_id=%s status=%s task_id=%s",
-            state.context_id, state.status.value, state.task_id,
-        )
-        await event_queue.close()
 
     async def cancel(
         self, context: RequestContext, event_queue: EventQueue
@@ -161,41 +175,51 @@ class AgentlingExecutor(AgentExecutor):
         enqueued on the slow path carries that id directly.
         """
         task_id = context.task_id
-        if not task_id:
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    "CancelTask requires a task_id.",
-                    context_id=context.context_id,
+        with otel_span("agentling.a2a.cancel", {
+            "agent.via": "a2a",
+            "task.context_id": context.context_id or "",
+            "task.id": task_id or "",
+        }) as span:
+            if not task_id:
+                span.set_attribute("a2a.outcome", "missing_task_id")
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        "CancelTask requires a task_id.",
+                        context_id=context.context_id,
+                    )
                 )
-            )
-            await event_queue.close()
-            return
+                await event_queue.close()
+                return
 
-        try:
-            state = await self._engine.cancel(task_id=task_id)
-        except TaskNotFoundError:
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    f"Task {task_id} not found.",
-                    context_id=context.context_id,
+            try:
+                state = await self._engine.cancel(task_id=task_id)
+            except TaskNotFoundError:
+                span.set_attribute("a2a.outcome", "not_found")
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        f"Task {task_id} not found.",
+                        context_id=context.context_id,
+                    )
                 )
-            )
-            await event_queue.close()
-            return
-        except Exception:  # noqa: BLE001
-            logger.exception("cancel failed for task %s", task_id)
-            await event_queue.enqueue_event(
-                _agent_text_message(
-                    "Internal error during cancel.",
-                    context_id=context.context_id,
+                await event_queue.close()
+                return
+            except Exception:  # noqa: BLE001
+                span.set_attribute("a2a.outcome", "exception")
+                logger.exception("cancel failed for task %s", task_id)
+                await event_queue.enqueue_event(
+                    _agent_text_message(
+                        "Internal error during cancel.",
+                        context_id=context.context_id,
+                    )
                 )
-            )
-            await event_queue.close()
-            return
+                await event_queue.close()
+                return
 
-        # Enqueue the updated Task so the SDK relays the cancelled state.
-        await event_queue.enqueue_event(task_state_to_a2a_task(state))
-        await event_queue.close()
+            span.set_attribute("task.status", state.status.value)
+            span.set_attribute("a2a.outcome", "cancelled")
+            # Enqueue the updated Task so the SDK relays the cancelled state.
+            await event_queue.enqueue_event(task_state_to_a2a_task(state))
+            await event_queue.close()
 
 
 def _format_busy(e: ContextBusyError) -> str:

--- a/src/agentlings/protocol/mcp.py
+++ b/src/agentlings/protocol/mcp.py
@@ -34,6 +34,7 @@ from agentlings.core.task import (
     TaskState,
     TaskStatus,
 )
+from agentlings.core.telemetry import otel_span
 
 logger = logging.getLogger(__name__)
 
@@ -113,60 +114,79 @@ def create_mcp_server(
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-        if name != agent_card.name:
-            return _error_payload("unknown_tool", f"Unknown tool: {name}")
-
         message = arguments.get("message")
         task_id = arguments.get("taskId")
         context_id = arguments.get("contextId")
         wait_seconds = arguments.get("waitSeconds", 0.0)
+        op = "poll" if task_id else "spawn"
 
-        if (message is None or message == "") and not task_id:
-            return _error_payload(
-                "invalid_input",
-                "Either `message` or `taskId` must be provided.",
-            )
-        if message and task_id:
-            return _error_payload(
-                "invalid_input",
-                "`message` and `taskId` are mutually exclusive.",
-            )
+        with otel_span("agentling.mcp.call_tool", {
+            "agent.via": "mcp",
+            "mcp.tool_name": name,
+            "mcp.operation": op,
+            "task.context_id": context_id or "",
+            "task.id": task_id or "",
+            "mcp.message_chars": len(message or ""),
+        }) as span:
+            if name != agent_card.name:
+                span.set_attribute("mcp.outcome", "unknown_tool")
+                return _error_payload("unknown_tool", f"Unknown tool: {name}")
 
-        try:
-            if task_id:
-                state = await engine.poll(
-                    task_id=task_id,
-                    context_id=context_id,
-                    wait_seconds=wait_seconds,
-                    cap_seconds=await_seconds,
+            if (message is None or message == "") and not task_id:
+                span.set_attribute("mcp.outcome", "invalid_input")
+                return _error_payload(
+                    "invalid_input",
+                    "Either `message` or `taskId` must be provided.",
                 )
-            else:
-                assert message is not None
-                state = await engine.spawn(
-                    message=message,
-                    context_id=context_id,
-                    via="mcp",
-                    await_seconds=await_seconds,
+            if message and task_id:
+                span.set_attribute("mcp.outcome", "invalid_input")
+                return _error_payload(
+                    "invalid_input",
+                    "`message` and `taskId` are mutually exclusive.",
                 )
-        except ContextBusyError as e:
-            return _error_payload(
-                "context_busy",
-                str(e),
-                active_task_id=e.active_task_id,
-                context_id=e.context_id,
-            )
-        except TaskNotFoundError as e:
-            return _error_payload("task_not_found", str(e), task_id=e.task_id)
-        except TaskContextMismatchError as e:
-            return _error_payload(
-                "task_context_mismatch",
-                str(e),
-                task_id=e.task_id,
-            )
-        except InvalidTaskInputError as e:
-            return _error_payload("invalid_input", str(e))
 
-        return _format_state(state, await_seconds)
+            try:
+                if task_id:
+                    state = await engine.poll(
+                        task_id=task_id,
+                        context_id=context_id,
+                        wait_seconds=wait_seconds,
+                        cap_seconds=await_seconds,
+                    )
+                else:
+                    assert message is not None
+                    state = await engine.spawn(
+                        message=message,
+                        context_id=context_id,
+                        via="mcp",
+                        await_seconds=await_seconds,
+                    )
+            except ContextBusyError as e:
+                span.set_attribute("mcp.outcome", "context_busy")
+                return _error_payload(
+                    "context_busy",
+                    str(e),
+                    active_task_id=e.active_task_id,
+                    context_id=e.context_id,
+                )
+            except TaskNotFoundError as e:
+                span.set_attribute("mcp.outcome", "task_not_found")
+                return _error_payload("task_not_found", str(e), task_id=e.task_id)
+            except TaskContextMismatchError as e:
+                span.set_attribute("mcp.outcome", "task_context_mismatch")
+                return _error_payload(
+                    "task_context_mismatch",
+                    str(e),
+                    task_id=e.task_id,
+                )
+            except InvalidTaskInputError as e:
+                span.set_attribute("mcp.outcome", "invalid_input")
+                return _error_payload("invalid_input", str(e))
+
+            span.set_attribute("mcp.outcome", state.status.value)
+            span.set_attribute("task.status", state.status.value)
+            span.set_attribute("task.id", state.task_id)
+            return _format_state(state, await_seconds)
 
     return server
 

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
@@ -27,7 +28,7 @@ from agentlings.core.scheduler import run_scheduler
 from agentlings.core.skills import discover_skills
 from agentlings.core.sleep import SleepCycle
 from agentlings.core.store import JournalStore
-from agentlings.core.telemetry import init_telemetry
+from agentlings.core.telemetry import init_telemetry, otel_span
 from agentlings.log import setup_logging
 from agentlings.protocol.a2a import AgentlingExecutor
 from agentlings.protocol.a2a_task_store import EngineTaskStore
@@ -70,6 +71,66 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
         return await call_next(request)
+
+
+class TelemetryMiddleware(BaseHTTPMiddleware):
+    """Wrap each non-public HTTP request in an ``agentling.http.request`` span.
+
+    Extracts a W3C ``traceparent`` header when present so callers' traces
+    stitch through into the engine spans below. When telemetry is disabled
+    the underlying span helper is a no-op, so this middleware has no
+    measurable cost.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        # Skip discovery endpoints — they're hit on every Agent Card refresh
+        # and would generate large amounts of low-value span volume.
+        if request.url.path in _PUBLIC_PATHS:
+            return await call_next(request)
+
+        traceparent = request.headers.get("traceparent")
+        attributes: dict[str, Any] = {
+            "http.method": request.method,
+            "http.target": request.url.path,
+        }
+        if traceparent:
+            attributes["http.traceparent"] = traceparent
+
+        # Inject the inbound traceparent into the OTel context so child
+        # spans (engine.spawn, completion, etc.) become descendants of the
+        # caller's span. Best-effort: skipped when the OTel API is missing.
+        token = None
+        if traceparent:
+            try:
+                from opentelemetry import context as otel_context
+                from opentelemetry.propagators.textmap import default_getter
+                from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+                propagator = TraceContextTextMapPropagator()
+                ctx = propagator.extract(
+                    {"traceparent": traceparent},
+                    getter=default_getter,
+                )
+                token = otel_context.attach(ctx)
+            except Exception:  # noqa: BLE001 — propagation is best-effort
+                token = None
+
+        start = time.monotonic()
+        try:
+            with otel_span("agentling.http.request", attributes) as span:
+                response = await call_next(request)
+                span.set_attribute("http.status_code", response.status_code)
+                span.set_attribute(
+                    "http.duration_seconds",
+                    round(time.monotonic() - start, 4),
+                )
+                return response
+        finally:
+            if token is not None:
+                try:
+                    from opentelemetry import context as otel_context
+                    otel_context.detach(token)
+                except Exception:  # noqa: BLE001
+                    pass
 
 
 def _create_app(config: AgentConfig | None = None) -> Starlette:
@@ -230,6 +291,8 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
     ]
 
     middleware = [
+        # Telemetry runs outermost so it observes auth failures too.
+        Middleware(TelemetryMiddleware),
         Middleware(APIKeyMiddleware, api_key=config.agent_api_key),
     ]
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,9 +1,37 @@
-"""Tests for telemetry initialization and no-op behavior."""
+"""Tests for telemetry initialization, no-op behavior, and emitted instrumentation.
+
+The "wired" tests stand up a full in-memory OTel pipeline (trace +
+metric exporters) and run real LLM completions and engine spawns
+through it, asserting the spans + metrics observers see what we expect.
+"""
 
 from __future__ import annotations
 
+from typing import Iterator
+
+import pytest
+
+import agentlings.core.telemetry as tele
 from agentlings.config import TelemetryConfig
-from agentlings.core.telemetry import _NoOpMeter, _NoOpTracer, get_meter, get_tracer, otel_span, sleep_span
+from agentlings.core.telemetry import (
+    _NoOpMeter,
+    _NoOpTracer,
+    attach_context,
+    capture_context,
+    get_meter,
+    get_tracer,
+    otel_span,
+    record_journal_append,
+    record_journal_replay,
+    record_llm_usage,
+    record_tool_duration,
+    sleep_span,
+)
+
+
+# --------------------------------------------------------------------------- #
+# No-op safety net (telemetry disabled, no OTel global provider configured)
+# --------------------------------------------------------------------------- #
 
 
 class TestNoOp:
@@ -33,6 +61,22 @@ class TestNoOp:
             with otel_span("child", {"level": "child"}) as child:
                 child.set_attribute("extra", "value")
 
+    def test_record_helpers_safe_when_disabled(self) -> None:
+        # All helpers must be safe to call when no provider is configured.
+        record_llm_usage(
+            {"input_tokens": 10, "output_tokens": 5},
+            model="mock", agent_name="test",
+        )
+        record_tool_duration("bash", 0.123, False)
+        record_journal_append("parent", 256, 0.001)
+        record_journal_replay("parent", 17, 0.002)
+
+    def test_capture_context_safe_when_disabled(self) -> None:
+        ctx = capture_context()
+        with attach_context(ctx):
+            with otel_span("inside") as s:
+                s.set_attribute("ok", True)
+
 
 class TestGetTracer:
     def test_returns_tracer(self) -> None:
@@ -44,3 +88,224 @@ class TestGetMeter:
     def test_returns_meter(self) -> None:
         meter = get_meter()
         assert meter is not None
+
+
+# --------------------------------------------------------------------------- #
+# Wired-up OTel: real span + metric exporters in-memory
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def otel_pipeline() -> Iterator[dict]:
+    """Wire in-memory tracer + meter providers into the telemetry module.
+
+    Pulls the tracer and meter directly off provider instances rather than
+    via ``trace.set_tracer_provider`` / ``metrics.set_meter_provider`` —
+    OTel forbids overriding an already-set global provider, and a prior
+    test in the same process likely fixed the global to a default proxy.
+    Bypassing the global lets the fixture work in any test order.
+
+    Yields a dict carrying ``spans()`` and ``metrics()`` accessors. Cleans
+    up the telemetry module's state so other tests stay isolated.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+
+    tele._tracer = tracer_provider.get_tracer("agentling")
+    tele._meter = meter_provider.get_meter("agentling")
+    tele._initialized = True
+    tele._instruments.clear()
+
+    def all_metrics() -> list:
+        data = metric_reader.get_metrics_data()
+        out: list = []
+        if data is None:
+            return out
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for metric in sm.metrics:
+                    out.append(metric)
+        return out
+
+    yield {
+        "spans": span_exporter.get_finished_spans,
+        "metrics": all_metrics,
+    }
+
+    tele._tracer = None
+    tele._meter = None
+    tele._initialized = False
+    tele._instruments.clear()
+
+
+def _metric_names(metrics_list: list) -> set[str]:
+    return {m.name for m in metrics_list}
+
+
+class TestLLMTokenTelemetry:
+    """Token histograms + counters emit via the mock backend."""
+
+    @pytest.mark.asyncio
+    async def test_mock_complete_emits_token_metrics(self, otel_pipeline) -> None:
+        from agentlings.core.llm import MockLLMClient
+
+        client = MockLLMClient()
+        response = await client.complete(
+            system=[{"type": "text", "text": "sys"}],
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+            tools=[],
+        )
+
+        assert response.usage["input_tokens"] >= 1
+        assert response.usage["output_tokens"] >= 1
+        assert response.model == MockLLMClient.MOCK_MODEL
+
+        names = _metric_names(otel_pipeline["metrics"]())
+        assert "agentling.llm.input_tokens" in names
+        assert "agentling.llm.output_tokens" in names
+        assert "agentling.llm.total_tokens" in names
+        assert "agentling.llm.input_tokens_total" in names
+        assert "agentling.llm.output_tokens_total" in names
+        assert "agentling.llm.calls_total" in names
+
+    def test_record_llm_usage_emits_cache_metrics(self, otel_pipeline) -> None:
+        record_llm_usage(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 80,
+            },
+            model="claude-sonnet-4-6",
+            agent_name="agent",
+        )
+        names = _metric_names(otel_pipeline["metrics"]())
+        assert "agentling.llm.cache_creation_input_tokens" in names
+        assert "agentling.llm.cache_read_input_tokens" in names
+        assert "agentling.llm.cache_hit_ratio" in names
+
+
+class TestCompletionSpanTree:
+    """Completion + tool spans emit and stack as parent → child."""
+
+    @pytest.mark.asyncio
+    async def test_completion_span_records_token_totals(self, otel_pipeline) -> None:
+        from agentlings.core.completion import run_completion
+        from agentlings.core.llm import MockLLMClient
+        from agentlings.tools.registry import ToolRegistry
+
+        client = MockLLMClient()
+        registry = ToolRegistry()
+
+        result = await run_completion(
+            llm=client,
+            system=[],
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            tools=registry,
+        )
+
+        assert result.token_usage["input"] >= 1
+        assert result.token_usage["output"] >= 1
+
+        spans = otel_pipeline["spans"]()
+        names = {s.name for s in spans}
+        assert "agentling.completion" in names
+        assert "agentling.completion.llm_call" in names
+        assert "agentling.llm.complete" in names
+
+        cycle_span = next(s for s in spans if s.name == "agentling.completion")
+        assert cycle_span.attributes["completion.input_tokens"] >= 1
+        assert cycle_span.attributes["completion.output_tokens"] >= 1
+
+
+class TestEngineSpawnContextPropagation:
+    """The worker span hangs off the caller's span via captured context."""
+
+    @pytest.mark.asyncio
+    async def test_worker_span_descends_from_caller_span(
+        self, otel_pipeline, test_config, tmp_data_dir
+    ) -> None:
+        from agentlings.core.llm import MockLLMClient
+        from agentlings.core.store import JournalStore
+        from agentlings.core.task import TaskEngine
+        from agentlings.tools.registry import ToolRegistry
+
+        store = JournalStore(tmp_data_dir)
+        llm = MockLLMClient()
+        engine = TaskEngine(
+            config=test_config, store=store, llm=llm, tools=ToolRegistry(),
+        )
+
+        with otel_span("test.outer") as outer:
+            outer.set_attribute("test", True)
+            await engine.spawn(message="hi", await_seconds=5.0)
+
+        spans = otel_pipeline["spans"]()
+        spans_by_name = {s.name: s for s in spans}
+
+        outer = spans_by_name["test.outer"]
+        spawn_span = spans_by_name["agentling.engine.spawn"]
+        worker_span = spans_by_name["agentling.task.worker"]
+
+        # spawn is a direct child of the outer caller span.
+        assert spawn_span.parent.span_id == outer.context.span_id
+        # The worker span lives inside the same trace because we re-attached
+        # the captured context across the asyncio.create_task boundary.
+        assert worker_span.context.trace_id == outer.context.trace_id
+
+    @pytest.mark.asyncio
+    async def test_worker_span_carries_token_totals(
+        self, otel_pipeline, test_config, tmp_data_dir
+    ) -> None:
+        from agentlings.core.llm import MockLLMClient
+        from agentlings.core.store import JournalStore
+        from agentlings.core.task import TaskEngine
+        from agentlings.tools.registry import ToolRegistry
+
+        store = JournalStore(tmp_data_dir)
+        llm = MockLLMClient()
+        engine = TaskEngine(
+            config=test_config, store=store, llm=llm, tools=ToolRegistry(),
+        )
+
+        await engine.spawn(message="ping", await_seconds=5.0)
+
+        spans = otel_pipeline["spans"]()
+        worker = next(s for s in spans if s.name == "agentling.task.worker")
+        assert worker.attributes["task.input_tokens"] >= 1
+        assert worker.attributes["task.output_tokens"] >= 1
+        assert worker.attributes["task.terminal"] == "completed"
+
+
+class TestJournalMetrics:
+    """JournalStore append/replay paths emit duration + bytes metrics."""
+
+    def test_append_and_replay_record_metrics(self, otel_pipeline, tmp_data_dir) -> None:
+        from agentlings.core.models import MessageEntry
+        from agentlings.core.store import JournalStore
+
+        store = JournalStore(tmp_data_dir)
+        store.create("ctx-1")
+        store.append("ctx-1", MessageEntry(
+            ctx="ctx-1",
+            role="user",
+            content=[{"type": "text", "text": "hello"}],
+        ))
+        store.replay("ctx-1")
+
+        names = _metric_names(otel_pipeline["metrics"]())
+        assert "agentling.journal.append_seconds" in names
+        assert "agentling.journal.replay_seconds" in names
+        assert "agentling.journal.bytes_appended_total" in names


### PR DESCRIPTION
Telemetry was already configurable but only thinly wired — most of the framework was invisible to a collector. This PR makes telemetry a first-class operability surface (still off by default), with token telemetry in particular wired end-to-end so a single trace surfaces the full token bill for a task.

- Spans now cover every layer top-to-bottom: `agentling.http.request` → `.a2a.execute`/`.mcp.call_tool` → `.engine.spawn`/`.poll`/`.cancel` → `.task.worker` → `.completion` → `.completion.llm_call` → `.completion.tool_exec` → `.llm.complete` (plus `count_tokens`, `batch_*`).
- Caller OTel context is captured at `engine.spawn` and re-attached inside the worker, so traces stitch across the `asyncio.create_task` boundary instead of fragmenting.
- Starlette middleware extracts the inbound W3C `traceparent` so external callers' traces continue through.
- LLM clients capture the full Anthropic `usage` block (input, output, cache_creation, cache_read) and emit per-call histograms + monotonic counters labeled by `llm.model` and `llm.path=live|batch`. Cache hit ratio surfaces as its own histogram. Token totals are stamped on the completion and worker spans.
- Per-tool duration histogram labeled by `tool.name` and `tool.is_error`.
- Journal store emits append/replay duration histograms and bytes-appended/entries-replayed counters with `journal.target=parent|sub`.
- Recovery pass on startup gets its own span tree.
- Tests stand up an in-memory OTel pipeline (`InMemorySpanExporter` + `InMemoryMetricReader`) and assert the full span tree, token metrics, journal metrics, and that the worker span is a descendant of an outer caller span.
- Bumps to 0.5.0.

Off by default. README OpenTelemetry section now lists every span and every metric with labels.