### PR TITLE
feat: split mcp tool into spawn and get_task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.5.0"
+version = "0.6.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/protocol/mcp.py
+++ b/src/agentlings/protocol/mcp.py
@@ -1,17 +1,17 @@
-"""MCP protocol server exposing the agentling as a single task-aware tool.
+"""MCP protocol server exposing the agentling as task-aware tools.
 
-The tool has four input fields:
+Two tools are registered, mirroring A2A's ``message/send`` + ``tasks/get``:
 
-- ``contextId`` (optional) — which conversation to append to or continue.
-- ``message`` (optional) — a new request to the agent.
-- ``taskId`` (optional) — an existing task to poll.
-- ``waitSeconds`` (optional) — when polling, how long to block for completion.
+- ``<agent_name>`` — start a new task. Inputs: ``message`` (required),
+  ``contextId`` (optional).
+- ``<agent_name>__get_task`` — poll an existing task. Inputs: ``taskId``
+  (required), ``contextId`` (optional), ``waitSeconds`` (optional).
 
-``message`` and ``taskId`` are mutually exclusive. Sending ``message`` starts a
-task; sending ``taskId`` polls an existing one. In either case the response is
-a ``CallToolResult`` whose ``structuredContent`` tells the caller whether the
-task completed (and the final response) or is still working (with the taskId
-to poll later).
+Both schemas declare ``additionalProperties: false`` so the MCP SDK's
+input validator rejects unknown fields before the handler runs. Required
+fields are enforced the same way. The handler keeps only genuine
+business-logic checks (engine dispatch, error mapping). Responses are
+the same message-shape envelope in both cases.
 """
 
 from __future__ import annotations
@@ -44,11 +44,11 @@ def create_mcp_server(
     agent_card: AgentCard,
     config: AgentConfig,
 ) -> Server:
-    """Create an MCP server with a single task-aware tool.
+    """Create an MCP server exposing spawn + get_task tools.
 
     Args:
         loop: The message loop exposing the shared task engine.
-        agent_card: The agent card whose name and description define the tool.
+        agent_card: The agent card whose name and description define the tools.
         config: Agent configuration (for the await timeout cap).
 
     Returns:
@@ -58,18 +58,16 @@ def create_mcp_server(
     engine = loop.engine
     await_seconds = float(getattr(config, "agent_task_await_seconds", 60))
 
-    tool = Tool(
-        name=agent_card.name,
+    spawn_name = agent_card.name
+    get_task_name = f"{agent_card.name}__get_task"
+
+    spawn_tool = Tool(
+        name=spawn_name,
         description=(
             f"{agent_card.description}\n\n"
-            "Exactly one of `message` or `taskId` must be provided:\n"
-            "- `message`: start a new task (natural-language request).\n"
-            "- `taskId`: poll an existing task returned by a prior call "
-            "whose status was `working`.\n\n"
-            "The response's `structuredContent.status` is either `completed` "
-            "(final response in `message`) or `working` (retry with `taskId`). "
-            "`waitSeconds` applies only to polls and is capped at "
-            f"{int(await_seconds)} seconds."
+            "Start a new task. The response's `status` is either `completed` "
+            f"(final response in `message`) or `working` — in the working "
+            f"case, retry via `{get_task_name}` with the returned `taskId`."
         ),
         inputSchema={
             "type": "object",
@@ -77,48 +75,86 @@ def create_mcp_server(
                 "contextId": {
                     "type": "string",
                     "description": (
-                        "Context ID from a previous response. Optional. Include "
-                        "to continue an existing conversation."
+                        "Context ID from a previous response. Optional. "
+                        "Include to continue an existing conversation."
                     ),
                 },
                 "message": {
                     "type": "string",
-                    "description": (
-                        "Natural language request to the agent. Mutually "
-                        "exclusive with `taskId`."
-                    ),
+                    "description": "Natural language request to the agent.",
                 },
+            },
+            "required": ["message"],
+            "additionalProperties": False,
+        },
+    )
+
+    get_task_tool = Tool(
+        name=get_task_name,
+        description=(
+            f"Poll the state of a task previously returned by `{spawn_name}` "
+            "whose status was `working`. The response uses the same envelope "
+            "shape: `status` is `completed`, `working`, `failed`, or "
+            f"`cancelled`. `waitSeconds` is capped at {int(await_seconds)} "
+            "seconds server-side."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
                 "taskId": {
                     "type": "string",
                     "description": (
-                        "Task ID returned by a prior call that yielded a working "
-                        "status. Mutually exclusive with `message`."
+                        "Task ID returned by a prior call that yielded a "
+                        "working status."
+                    ),
+                },
+                "contextId": {
+                    "type": "string",
+                    "description": (
+                        "Optional context ID. When provided, the server "
+                        "asserts the task belongs to it."
                     ),
                 },
                 "waitSeconds": {
                     "type": "number",
                     "minimum": 0,
                     "description": (
-                        "Maximum seconds to block on a poll, capped server-side. "
-                        "Ignored when `message` is provided."
+                        "Maximum seconds to block on this poll, capped "
+                        "server-side."
                     ),
                 },
             },
+            "required": ["taskId"],
             "additionalProperties": False,
         },
     )
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        return [tool]
+        return [spawn_tool, get_task_tool]
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-        message = arguments.get("message")
-        task_id = arguments.get("taskId")
         context_id = arguments.get("contextId")
-        wait_seconds = arguments.get("waitSeconds", 0.0)
-        op = "poll" if task_id else "spawn"
+
+        if name == spawn_name:
+            op = "spawn"
+            message = arguments.get("message")
+            task_id = None
+            wait_seconds = 0.0
+        elif name == get_task_name:
+            op = "poll"
+            message = None
+            task_id = arguments.get("taskId")
+            wait_seconds = arguments.get("waitSeconds", 0.0)
+        else:
+            with otel_span("agentling.mcp.call_tool", {
+                "agent.via": "mcp",
+                "mcp.tool_name": name,
+                "mcp.operation": "unknown",
+            }) as span:
+                span.set_attribute("mcp.outcome", "unknown_tool")
+            return _error_payload("unknown_tool", f"Unknown tool: {name}")
 
         with otel_span("agentling.mcp.call_tool", {
             "agent.via": "mcp",
@@ -128,25 +164,9 @@ def create_mcp_server(
             "task.id": task_id or "",
             "mcp.message_chars": len(message or ""),
         }) as span:
-            if name != agent_card.name:
-                span.set_attribute("mcp.outcome", "unknown_tool")
-                return _error_payload("unknown_tool", f"Unknown tool: {name}")
-
-            if (message is None or message == "") and not task_id:
-                span.set_attribute("mcp.outcome", "invalid_input")
-                return _error_payload(
-                    "invalid_input",
-                    "Either `message` or `taskId` must be provided.",
-                )
-            if message and task_id:
-                span.set_attribute("mcp.outcome", "invalid_input")
-                return _error_payload(
-                    "invalid_input",
-                    "`message` and `taskId` are mutually exclusive.",
-                )
-
             try:
-                if task_id:
+                if op == "poll":
+                    assert task_id is not None
                     state = await engine.poll(
                         task_id=task_id,
                         context_id=context_id,
@@ -186,37 +206,29 @@ def create_mcp_server(
             span.set_attribute("mcp.outcome", state.status.value)
             span.set_attribute("task.status", state.status.value)
             span.set_attribute("task.id", state.task_id)
-            return _format_state(state, await_seconds)
+            return _format_state(state, await_seconds, get_task_name)
 
     return server
 
 
-def _format_state(state: TaskState, await_seconds: float) -> list[TextContent]:
+def _format_state(
+    state: TaskState, await_seconds: float, get_task_name: str
+) -> list[TextContent]:
     """Turn a ``TaskState`` into an MCP ``CallToolResult`` payload."""
-    structured: dict[str, Any] = {
-        "taskId": state.task_id,
-        "contextId": state.context_id,
-        "status": state.status.value,
-    }
     if state.status == TaskStatus.COMPLETED:
         response_text = _extract_text(state.content)
-        structured["message"] = response_text
         envelope = {
             "contextId": state.context_id,
             "taskId": state.task_id,
             "message": response_text,
             "status": state.status.value,
         }
-        return [TextContent(
-            type="text",
-            text=json.dumps(envelope),
-        )]
+        return [TextContent(type="text", text=json.dumps(envelope))]
 
     if state.status == TaskStatus.WORKING:
-        structured["pollAfterMs"] = 10_000
         human = (
-            f"Task {state.task_id} still running. "
-            f"Call again with taskId={state.task_id} to poll "
+            f"Task {state.task_id} still running. Call `{get_task_name}` "
+            f"with taskId={state.task_id} to poll "
             f"(waitSeconds up to {int(await_seconds)})."
         )
         envelope = {
@@ -228,7 +240,6 @@ def _format_state(state: TaskState, await_seconds: float) -> list[TextContent]:
         }
         return [TextContent(type="text", text=json.dumps(envelope))]
 
-    # Failed or cancelled — return an error-shaped payload.
     envelope = {
         "contextId": state.context_id,
         "taskId": state.task_id,

--- a/tests/integration/mcp_client.py
+++ b/tests/integration/mcp_client.py
@@ -52,23 +52,64 @@ class MCPTestClient:
                     for t in result.tools
                 ]
 
-    async def _tool_name(self) -> str:
-        async with streamablehttp_client(
-            self._url, headers=self._headers
-        ) as (read, write, _):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                tools = await session.list_tools()
-                return tools.tools[0].name
+    async def _spawn_tool_name(self, session: ClientSession) -> str:
+        tools = await session.list_tools()
+        for t in tools.tools:
+            if not t.name.endswith("__get_task"):
+                return t.name
+        raise RuntimeError("no spawn tool found")
 
-    async def _call(self, arguments: dict[str, Any]) -> MCPToolCallResult:
+    async def _get_task_tool_name(self, session: ClientSession) -> str:
+        tools = await session.list_tools()
+        for t in tools.tools:
+            if t.name.endswith("__get_task"):
+                return t.name
+        raise RuntimeError("no get_task tool found")
+
+    async def _call_named(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> MCPToolCallResult:
         async with streamablehttp_client(
             self._url, headers=self._headers
         ) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                tools = await session.list_tools()
-                tool_name = tools.tools[0].name
+                result = await session.call_tool(tool_name, arguments)
+                text_content = result.content[0].text  # type: ignore[attr-defined]
+                parsed = json.loads(text_content)
+                return MCPToolCallResult(
+                    context_id=parsed.get("contextId"),
+                    message=parsed.get("message", ""),
+                    status=parsed.get("status", parsed.get("error", "")),
+                    task_id=parsed.get("taskId") or parsed.get("activeTaskId"),
+                    raw=parsed,
+                )
+
+    async def _call_spawn(self, arguments: dict[str, Any]) -> MCPToolCallResult:
+        async with streamablehttp_client(
+            self._url, headers=self._headers
+        ) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tool_name = await self._spawn_tool_name(session)
+                result = await session.call_tool(tool_name, arguments)
+                text_content = result.content[0].text  # type: ignore[attr-defined]
+                parsed = json.loads(text_content)
+                return MCPToolCallResult(
+                    context_id=parsed.get("contextId"),
+                    message=parsed.get("message", ""),
+                    status=parsed.get("status", parsed.get("error", "")),
+                    task_id=parsed.get("taskId") or parsed.get("activeTaskId"),
+                    raw=parsed,
+                )
+
+    async def _call_get_task(self, arguments: dict[str, Any]) -> MCPToolCallResult:
+        async with streamablehttp_client(
+            self._url, headers=self._headers
+        ) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tool_name = await self._get_task_tool_name(session)
                 result = await session.call_tool(tool_name, arguments)
                 text_content = result.content[0].text  # type: ignore[attr-defined]
                 parsed = json.loads(text_content)
@@ -87,7 +128,7 @@ class MCPTestClient:
         args: dict[str, Any] = {"message": message}
         if context_id is not None:
             args["contextId"] = context_id
-        return await self._call(args)
+        return await self._call_spawn(args)
 
     async def poll_task(
         self,
@@ -95,12 +136,46 @@ class MCPTestClient:
         context_id: str | None = None,
         wait_seconds: float = 0.0,
     ) -> MCPToolCallResult:
-        """Poll an existing task for its current state."""
+        """Poll an existing task for its current state via the get_task tool."""
         args: dict[str, Any] = {"taskId": task_id, "waitSeconds": wait_seconds}
         if context_id is not None:
             args["contextId"] = context_id
-        return await self._call(args)
+        return await self._call_get_task(args)
 
-    async def call_invalid(self, arguments: dict[str, Any]) -> MCPToolCallResult:
-        """Issue an arbitrary arguments payload (for validation tests)."""
-        return await self._call(arguments)
+    async def call_invalid(
+        self,
+        arguments: dict[str, Any],
+        *,
+        on_get_task: bool = False,
+    ) -> MCPToolCallResult:
+        """Issue an arbitrary arguments payload that the handler will shape
+        as a JSON envelope (engine-level errors only)."""
+        if on_get_task:
+            return await self._call_get_task(arguments)
+        return await self._call_spawn(arguments)
+
+    async def call_raw(
+        self,
+        arguments: dict[str, Any],
+        *,
+        on_get_task: bool = False,
+    ) -> tuple[bool, str]:
+        """Issue a raw call and return (isError, content_text).
+
+        For asserting SDK-level schema validation responses, which are plain
+        text (not the handler's JSON envelope) and would otherwise fail to
+        parse via ``_call_named``.
+        """
+        async with streamablehttp_client(
+            self._url, headers=self._headers
+        ) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tool_name = (
+                    await self._get_task_tool_name(session)
+                    if on_get_task
+                    else await self._spawn_tool_name(session)
+                )
+                result = await session.call_tool(tool_name, arguments)
+                text = result.content[0].text  # type: ignore[attr-defined]
+                return bool(result.isError), text

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -5,39 +5,54 @@ import pytest
 from tests.integration.mcp_client import MCPTestClient
 
 
+def _by_name(tools: list[dict], suffix: str = "") -> dict:
+    for t in tools:
+        if suffix:
+            if t["name"].endswith(suffix):
+                return t
+        else:
+            if not t["name"].endswith("__get_task"):
+                return t
+    raise AssertionError(f"no tool found matching suffix={suffix!r}")
+
+
 class TestMCPToolsList:
     @pytest.mark.asyncio
-    async def test_lists_single_tool(self, mcp_client: MCPTestClient) -> None:
+    async def test_lists_two_tools(self, mcp_client: MCPTestClient) -> None:
         tools = await mcp_client.list_tools()
-        assert len(tools) == 1
+        assert len(tools) == 2
 
     @pytest.mark.asyncio
-    async def test_tool_name_matches_agent(self, mcp_client: MCPTestClient) -> None:
-        tools = await mcp_client.list_tools()
-        assert tools[0]["name"] == "test-agent"
-
-    @pytest.mark.asyncio
-    async def test_tool_schema_has_task_fields(
+    async def test_spawn_tool_name_matches_agent(
         self, mcp_client: MCPTestClient
     ) -> None:
         tools = await mcp_client.list_tools()
-        schema = tools[0]["inputSchema"]
+        spawn = _by_name(tools)
+        assert spawn["name"] == "test-agent"
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_name(self, mcp_client: MCPTestClient) -> None:
+        tools = await mcp_client.list_tools()
+        get_task = _by_name(tools, "__get_task")
+        assert get_task["name"] == "test-agent__get_task"
+
+    @pytest.mark.asyncio
+    async def test_spawn_schema_shape(self, mcp_client: MCPTestClient) -> None:
+        tools = await mcp_client.list_tools()
+        schema = _by_name(tools)["inputSchema"]
         props = schema["properties"]
-        assert "message" in props
-        assert "taskId" in props
-        assert "contextId" in props
-        assert "waitSeconds" in props
-        # v2: nothing is required; server validates mutual exclusion at call time.
-        assert schema.get("required", []) == []
+        assert set(props.keys()) == {"message", "contextId"}
+        assert schema.get("required", []) == ["message"]
+        assert schema.get("additionalProperties") is False
 
     @pytest.mark.asyncio
-    async def test_tool_schema_has_optional_context_id(
-        self, mcp_client: MCPTestClient
-    ) -> None:
+    async def test_get_task_schema_shape(self, mcp_client: MCPTestClient) -> None:
         tools = await mcp_client.list_tools()
-        schema = tools[0]["inputSchema"]
-        assert "contextId" in schema["properties"]
-        assert "contextId" not in schema.get("required", [])
+        schema = _by_name(tools, "__get_task")["inputSchema"]
+        props = schema["properties"]
+        assert set(props.keys()) == {"taskId", "contextId", "waitSeconds"}
+        assert schema.get("required", []) == ["taskId"]
+        assert schema.get("additionalProperties") is False
 
 
 class TestMCPToolCall:
@@ -75,7 +90,7 @@ class TestMCPToolCall:
 
 
 class TestMCPTaskPolling:
-    """Tests that exercise the poll path with a completed task."""
+    """Tests that exercise the get_task tool against a completed task."""
 
     @pytest.mark.asyncio
     async def test_poll_completed_task_returns_final_response(
@@ -103,39 +118,63 @@ class TestMCPTaskPolling:
         self, mcp_client: MCPTestClient
     ) -> None:
         polled = await mcp_client.poll_task("nonexistent-task-id")
-        # Error envelope uses raw["error"] and our dataclass maps it to status.
         assert polled.raw.get("error") == "task_not_found"
 
 
 class TestMCPInputValidation:
-    @pytest.mark.asyncio
-    async def test_missing_message_and_task_id(
-        self, mcp_client: MCPTestClient
-    ) -> None:
-        result = await mcp_client.call_invalid({})
-        assert result.raw.get("error") == "invalid_input"
+    """Schema-level validation comes from the MCP SDK's jsonschema pass.
+
+    With the split into two tools, mutual-exclusion is enforced by shape:
+    the spawn tool has no ``taskId`` field, the get_task tool has no
+    ``message`` field. Both schemas declare ``additionalProperties: false``
+    and required fields, so the SDK rejects malformed payloads before the
+    handler runs. Schema rejections come back as ``isError=True`` with a
+    plain-text ``"Input validation error"`` message — not the handler's
+    JSON envelope.
+    """
 
     @pytest.mark.asyncio
-    async def test_both_message_and_task_id(
+    async def test_spawn_rejects_extra_property(
         self, mcp_client: MCPTestClient
     ) -> None:
-        result = await mcp_client.call_invalid(
+        is_error, text = await mcp_client.call_raw(
             {"message": "hi", "taskId": "some-task"}
         )
-        assert result.raw.get("error") == "invalid_input"
+        assert is_error
+        assert "validation" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_spawn_rejects_missing_message(
+        self, mcp_client: MCPTestClient
+    ) -> None:
+        is_error, text = await mcp_client.call_raw({})
+        assert is_error
+        assert "validation" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_get_task_rejects_missing_task_id(
+        self, mcp_client: MCPTestClient
+    ) -> None:
+        is_error, text = await mcp_client.call_raw({}, on_get_task=True)
+        assert is_error
+        assert "validation" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_get_task_rejects_extra_property(
+        self, mcp_client: MCPTestClient
+    ) -> None:
+        is_error, text = await mcp_client.call_raw(
+            {"taskId": "abc", "message": "no"}, on_get_task=True
+        )
+        assert is_error
+        assert "validation" in text.lower()
 
     @pytest.mark.asyncio
     async def test_whitespace_only_message_rejected(
         self, mcp_client: MCPTestClient
     ) -> None:
-        """Engine-level validation must be caught and shaped cleanly.
-
-        Regression: when whitespace-only messages slipped past the
-        handler's ``message == ""`` literal check, the ``engine.spawn()``
-        raised ``InvalidTaskInputError`` which the handler attempted to
-        match in an ``except`` clause — but the name was not imported,
-        causing a ``NameError`` to propagate instead of a clean envelope.
-        """
+        """Whitespace-only messages pass schema validation but fail at the
+        engine; the handler maps ``InvalidTaskInputError`` onto an
+        ``invalid_input`` JSON envelope."""
         result = await mcp_client.call_invalid({"message": "   \n\t  "})
         assert result.raw.get("error") == "invalid_input"
-

--- a/tests/unit/test_mcp_handler.py
+++ b/tests/unit/test_mcp_handler.py
@@ -1,26 +1,33 @@
 """Unit tests for the MCP tool handler's schema-validation layering.
 
-The MCP SDK (1.10+) runs ``jsonschema.validate`` against the declared
-``inputSchema`` inside ``@server.call_tool()`` before the handler runs.
-The handler owns only genuine business logic (XOR between ``message``
-and ``taskId``, engine dispatch); schema-shape validation is delegated
-to the SDK. The contract test below asserts our schema is tight enough
-for the SDK to reject a malformed ``waitSeconds`` value.
+The MCP SDK (1.10+) runs ``jsonschema.validate`` against each tool's
+declared ``inputSchema`` inside ``@server.call_tool()`` before the
+handler runs. The handler owns only genuine business logic (engine
+dispatch, error mapping); schema-shape validation is delegated to the
+SDK. The contract tests below assert our schemas are tight enough for
+the SDK to reject:
+
+- malformed value types,
+- missing required fields, and
+- unknown ("extra") fields (``additionalProperties: false``).
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 from a2a.types import AgentCard
+from mcp.types import CallToolRequest, CallToolRequestParams
 
 from agentlings.config import AgentConfig
 from agentlings.core.llm import MockLLMClient
 from agentlings.core.loop import MessageLoop
 from agentlings.core.store import JournalStore
 from agentlings.protocol.agent_card import generate_agent_card
-from agentlings.protocol.mcp import create_mcp_server
+from agentlings.core.task import TaskState, TaskStatus
+from agentlings.protocol.mcp import _format_state, create_mcp_server
 from agentlings.tools.registry import ToolRegistry
 
 
@@ -36,21 +43,86 @@ def mcp_server(tmp_data_dir: Path, test_config: AgentConfig):
     return server, agent_card
 
 
-@pytest.mark.asyncio
-async def test_schema_validates_wait_seconds_type(mcp_server) -> None:
-    """The MCP SDK's inputSchema validation rejects malformed `waitSeconds`
-    before the handler runs. This asserts our declared schema is tight
-    enough for the SDK to catch a type violation."""
-    server, card = mcp_server
-    from mcp.types import CallToolRequest, CallToolRequestParams
+async def _invoke(server, tool_name: str, arguments: dict) -> str:
     handler = server.request_handlers[CallToolRequest]
     request = CallToolRequest(
         method="tools/call",
-        params=CallToolRequestParams(
-            name=card.name,
-            arguments={"taskId": "abc", "waitSeconds": "not-a-number"},
-        ),
+        params=CallToolRequestParams(name=tool_name, arguments=arguments),
     )
     result = await handler(request)
-    text = result.root.content[0].text
+    return result.root.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_task_schema_rejects_bad_wait_seconds(mcp_server) -> None:
+    """The SDK rejects ``waitSeconds`` of the wrong type before the
+    handler runs."""
+    server, card = mcp_server
+    text = await _invoke(
+        server,
+        f"{card.name}__get_task",
+        {"taskId": "abc", "waitSeconds": "not-a-number"},
+    )
     assert "Input validation error" in text
+
+
+@pytest.mark.asyncio
+async def test_spawn_schema_rejects_missing_message(mcp_server) -> None:
+    """The spawn tool requires ``message`` — empty payload is a schema
+    violation, not a handler-level branch."""
+    server, card = mcp_server
+    text = await _invoke(server, card.name, {})
+    assert "Input validation error" in text
+
+
+@pytest.mark.asyncio
+async def test_spawn_schema_rejects_extra_property(mcp_server) -> None:
+    """``additionalProperties: false`` is the bouncer — extras don't reach
+    the handler. Catches an LLM that fabricates a field like ``priority``
+    or tries to smuggle ``taskId`` onto a spawn call."""
+    server, card = mcp_server
+    text = await _invoke(
+        server,
+        card.name,
+        {"message": "hi", "taskId": "abc"},
+    )
+    assert "Input validation error" in text
+
+
+@pytest.mark.asyncio
+async def test_get_task_schema_rejects_missing_task_id(mcp_server) -> None:
+    """The get_task tool requires ``taskId`` — empty payload is rejected
+    by the SDK, not the handler."""
+    server, card = mcp_server
+    text = await _invoke(server, f"{card.name}__get_task", {})
+    assert "Input validation error" in text
+
+
+@pytest.mark.asyncio
+async def test_get_task_schema_rejects_extra_property(mcp_server) -> None:
+    """Extras on the poll path are likewise schema-rejected — e.g. an LLM
+    re-supplying ``message`` while polling."""
+    server, card = mcp_server
+    text = await _invoke(
+        server,
+        f"{card.name}__get_task",
+        {"taskId": "abc", "message": "no"},
+    )
+    assert "Input validation error" in text
+
+
+def test_working_envelope_points_at_get_task_tool() -> None:
+    """The working-state envelope must name the get_task tool the LLM
+    should call to poll. Otherwise the LLM either retries the spawn tool
+    (creating a new task) or hallucinates a tool name."""
+    state = TaskState(
+        task_id="task-123",
+        context_id="ctx-abc",
+        status=TaskStatus.WORKING,
+    )
+    [content] = _format_state(state, await_seconds=2.0, get_task_name="agent__get_task")
+    payload = json.loads(content.text)
+    assert payload["status"] == "working"
+    assert payload["taskId"] == "task-123"
+    assert "agent__get_task" in payload["message"]
+    assert "task-123" in payload["message"]


### PR DESCRIPTION
The single MCP tool overloaded `message` and `taskId` as mutually exclusive — awkward for the LLM (which had to learn the XOR) and out of step with A2A's `message/send` + `tasks/get` split. Two intent-shaped tools are clearer and let `additionalProperties: false` enforce the shape at the SDK boundary.

- `<agent_name>` — spawn-only: `{ contextId?, message }`, `required: ["message"]`.
- `<agent_name>__get_task` — poll: `{ taskId, contextId?, waitSeconds? }`, `required: ["taskId"]`.
- Both schemas declare `additionalProperties: false`. SDK rejects extras and missing requireds before the handler runs (e.g. an LLM smuggling `taskId` onto a spawn).
- Working-state envelope now names the `__get_task` tool the LLM should call.
- Engine error mapping (`context_busy`, `task_not_found`, `task_context_mismatch`, `invalid_input`) preserved.
- Bump 0.5.0 → 0.6.0 — MCP wire schema is breaking.

Tests cover both schemas (type, missing-required, extras), both call paths, and the working-state envelope's tool-name copy.