### PR TITLE
feat: surface await-window outcome on engine spawn/poll telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.6.0"
+version = "0.6.1"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/task.py
+++ b/src/agentlings/core/task.py
@@ -81,6 +81,7 @@ class _TaskMetrics:
     context_busy_rejections: Any
     crash_recovery_repaired: Any
     crash_recovery_failed: Any
+    await_window_timeouts: Any
 
 
 @functools.lru_cache(maxsize=1)
@@ -118,6 +119,13 @@ def _build_metrics() -> _TaskMetrics:
         crash_recovery_failed=m.create_counter(
             "agentling.tasks.crash_recovery_failed_total",
             description="Recovery passes that raised an exception for a context.",
+        ),
+        await_window_timeouts=m.create_counter(
+            "agentling.tasks.await_window_timeouts_total",
+            description=(
+                "Spawn/poll calls whose await window expired before the task "
+                "reached a terminal state. Used to size agent_task_await_seconds."
+            ),
         ),
     )
 
@@ -751,15 +759,21 @@ class TaskEngine:
                 extra={"task_id": task_id, "context_id": ctx_id, "via": via},
             )
 
+            await_outcome = "skipped"
             try:
                 if await_seconds > 0:
                     await asyncio.wait_for(
                         record.completion_event.wait(),
                         timeout=await_seconds,
                     )
+                    await_outcome = "completed"
             except asyncio.TimeoutError:
-                pass
+                await_outcome = "timed_out"
+                _METRICS.await_window_timeouts.add(
+                    1, {"operation": "spawn", "via": via}
+                )
 
+            span.set_attribute("task.await_outcome", await_outcome)
             state = self._state_from_task(task_id, ctx_id, record, task_journal)
             span.set_attribute("task.status", state.status.value)
             return state
@@ -812,16 +826,23 @@ class TaskEngine:
                     searched=f"context={resolved_ctx}",
                 )
 
+            await_outcome = "skipped"
             if wait_seconds > 0 and record is not None:
                 effective = min(wait_seconds, cap_seconds)
+                span.set_attribute("task.wait_capped_seconds", effective)
                 try:
                     await asyncio.wait_for(
                         record.completion_event.wait(),
                         timeout=effective,
                     )
+                    await_outcome = "completed"
                 except asyncio.TimeoutError:
-                    pass
+                    await_outcome = "timed_out"
+                    _METRICS.await_window_timeouts.add(
+                        1, {"operation": "poll"}
+                    )
 
+            span.set_attribute("task.await_outcome", await_outcome)
             record = self._registry.get(task_id) or record
             state = self._state_from_task(task_id, resolved_ctx, record, task_journal)
             span.set_attribute("task.status", state.status.value)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -128,6 +128,13 @@ def otel_pipeline() -> Iterator[dict]:
     tele._initialized = True
     tele._instruments.clear()
 
+    # The task module's _TaskMetrics is built once at import via lru_cache,
+    # so it captured a no-op counter before the fixture set the meter.
+    # Refresh it so async-path counters land in the in-memory reader.
+    import agentlings.core.task as task_module
+    task_module._build_metrics.cache_clear()
+    task_module._METRICS = task_module._build_metrics()
+
     def all_metrics() -> list:
         data = metric_reader.get_metrics_data()
         out: list = []
@@ -287,6 +294,104 @@ class TestEngineSpawnContextPropagation:
         assert worker.attributes["task.input_tokens"] >= 1
         assert worker.attributes["task.output_tokens"] >= 1
         assert worker.attributes["task.terminal"] == "completed"
+
+
+class TestAwaitWindowTelemetry:
+    """Spawn/poll surface their await-window outcome via span attributes + metric."""
+
+    @pytest.mark.asyncio
+    async def test_spawn_completed_within_window_records_completed(
+        self, otel_pipeline, test_config, tmp_data_dir
+    ) -> None:
+        from agentlings.core.llm import MockLLMClient
+        from agentlings.core.store import JournalStore
+        from agentlings.core.task import TaskEngine
+        from agentlings.tools.registry import ToolRegistry
+
+        engine = TaskEngine(
+            config=test_config,
+            store=JournalStore(tmp_data_dir),
+            llm=MockLLMClient(),
+            tools=ToolRegistry(),
+        )
+        await engine.spawn(message="hi", await_seconds=5.0)
+
+        spans = otel_pipeline["spans"]()
+        spawn = next(s for s in spans if s.name == "agentling.engine.spawn")
+        assert spawn.attributes["task.await_outcome"] == "completed"
+
+        names = _metric_names(otel_pipeline["metrics"]())
+        assert "agentling.tasks.await_window_timeouts_total" not in names
+
+    @pytest.mark.asyncio
+    async def test_spawn_timeout_records_timed_out_and_increments_counter(
+        self, otel_pipeline, test_config, tmp_data_dir
+    ) -> None:
+        from agentlings.core.store import JournalStore
+        from agentlings.core.task import TaskEngine
+        from agentlings.tools.registry import ToolRegistry
+        from tests.unit.test_task import ControllableLLM
+
+        llm = ControllableLLM()
+        engine = TaskEngine(
+            config=test_config,
+            store=JournalStore(tmp_data_dir),
+            llm=llm,
+            tools=ToolRegistry(),
+        )
+
+        state = await engine.spawn(message="slow", await_seconds=0.05)
+
+        spans = otel_pipeline["spans"]()
+        spawn = next(s for s in spans if s.name == "agentling.engine.spawn")
+        assert spawn.attributes["task.await_outcome"] == "timed_out"
+
+        names = _metric_names(otel_pipeline["metrics"]())
+        assert "agentling.tasks.await_window_timeouts_total" in names
+
+        from agentlings.core.llm import LLMResponse
+
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "ok"}], stop_reason="end_turn",
+        ))
+        rec = engine.registry.get(state.task_id)
+        if rec is not None:
+            import asyncio as _a
+            await _a.wait_for(rec.completion_event.wait(), timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_poll_records_wait_capping(
+        self, otel_pipeline, test_config, tmp_data_dir
+    ) -> None:
+        from agentlings.core.llm import LLMResponse
+        from agentlings.core.store import JournalStore
+        from agentlings.core.task import TaskEngine
+        from agentlings.tools.registry import ToolRegistry
+        from tests.unit.test_task import ControllableLLM
+
+        llm = ControllableLLM()
+        engine = TaskEngine(
+            config=test_config,
+            store=JournalStore(tmp_data_dir),
+            llm=llm,
+            tools=ToolRegistry(),
+        )
+        state = await engine.spawn(message="slow", await_seconds=0.05)
+
+        await engine.poll(state.task_id, wait_seconds=10.0, cap_seconds=0.05)
+
+        spans = otel_pipeline["spans"]()
+        poll = next(s for s in spans if s.name == "agentling.engine.poll")
+        assert poll.attributes["task.await_outcome"] == "timed_out"
+        assert poll.attributes["task.wait_capped_seconds"] == pytest.approx(0.05)
+
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "ok"}], stop_reason="end_turn",
+        ))
+        rec = engine.registry.get(state.task_id)
+        if rec is not None:
+            import asyncio as _a
+            await _a.wait_for(rec.completion_event.wait(), timeout=2.0)
 
 
 class TestJournalMetrics:


### PR DESCRIPTION
Operators tuning `agent_task_await_seconds` had no signal for whether requests were finishing inside the await window or yielding a working task handle on timeout. Tracing showed `task.status` only — which is the *task's* state, not the *handler's* outcome — so the two were indistinguishable.

- Stamp `task.await_outcome` (`completed`/`timed_out`/`skipped`) on `agentling.engine.spawn` and `agentling.engine.poll` spans.
- Add an `agentling.tasks.await_window_timeouts_total` counter labelled by `operation` (and `via` for spawn) so dashboards can rate the timeout fraction.
- On poll, also stamp `task.wait_capped_seconds` to make the requested-vs-capped gap visible when MCP callers pass `waitSeconds` above the server cap.
- Bumps to 0.6.1.