### PR TITLE
feat: tag conversation messages with their task_id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.6.1"
+version = "0.7.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/prompt.py
+++ b/src/agentlings/core/prompt.py
@@ -22,17 +22,44 @@ The following is your long-term memory — facts you have learned over time:
 DEFAULT_DATA_DIR_AWARENESS = """\
 ## Data Directory
 
-Your data directory is at {data_dir}. It contains:
-- memory/memory.json: your long-term memory (also provided above)
-- journals/YYYY-MM-DD.md: daily summaries of your past activity
-- conversations as *.jsonl: raw conversation logs
+Your data directory is at {data_dir}. Layout:
 
-You can read these files using your filesystem tools to recall past context \
-that is not in your current memory. For example:
-- List journals to see which days you were active
-- Read a journal to recall what happened on a specific day
-- Search across journals to find when an issue first appeared
-- Read conversation logs for full detail on a past interaction"""
+- {data_dir}/memory/memory.json — your long-term memory (also provided above)
+- {data_dir}/journals/YYYY-MM-DD.md — daily summaries of your past activity
+- {data_dir}/<context_id>/journal.jsonl — parent journal for a conversation \
+(merged user/assistant turns only)
+- {data_dir}/<context_id>/tasks/<task_id>.jsonl — sub-journal for a single \
+task's execution trace (every tool call, every response)
+
+Every user and assistant message in the conversation above is prefixed with a \
+``[task <id>]`` block indicating which task produced it. Use that id to inspect \
+the corresponding sub-journal if you need to know what was actually done — the \
+parent journal only carries final responses, never the tool-call trace.
+
+## Inspecting Your Own Tasks
+
+Sub-journals can be large — a long task may write hundreds of KB of tool output. \
+Never ``cat`` a sub-journal. Read only what you need:
+
+  Status check (cheap, always safe — last entry is the terminal marker):
+      tail -n 5 {data_dir}/<context_id>/tasks/<task_id>.jsonl
+
+    Look at the last entry's ``t`` field:
+      task_done    → completed; ``final_response`` holds the answer
+      task_fail    → failed; ``reason`` and ``error_details`` on the entry
+      task_cancel  → cancelled; ``reason`` on the entry
+      (no terminal) → still running or merge-back in progress
+
+  Find what tool calls a task made (bounded output):
+      jq -c 'select(.t=="msg" and .role=="assistant")' \
+{data_dir}/<context_id>/tasks/<task_id>.jsonl | head -c 8000
+
+  Find errors:
+      jq -c 'select(.t=="task_fail")' \
+{data_dir}/<context_id>/tasks/<task_id>.jsonl
+
+Ignore entries with ``t`` in ``{{task_dispatch, merge_start, merge_commit}}`` — \
+those are operational audit markers, not conversational content."""
 
 
 def build_system_prompt(

--- a/src/agentlings/core/store.py
+++ b/src/agentlings/core/store.py
@@ -52,6 +52,25 @@ class ContextNotFoundError(Exception):
     """Raised when a context ID does not correspond to an existing journal file."""
 
 
+def tag_message_content(
+    content: list[dict[str, Any]],
+    task_id: str | None,
+) -> list[dict[str, Any]]:
+    """Prepend a ``[task <id>]`` text block to a message's content list.
+
+    Surfaces the task identity that produced each merged-back message into the
+    LLM-visible conversation history. With this, the model can correlate any
+    user/assistant turn to the sub-journal that produced it (``tasks/<id>.jsonl``)
+    without the framework needing to inject anything into the system prompt.
+
+    Returns the content unchanged when ``task_id`` is ``None`` — pre-task-era
+    journals and any future entry type that omits the field replay verbatim.
+    """
+    if not task_id:
+        return content
+    return [{"type": "text", "text": f"[task {task_id}]"}, *content]
+
+
 def _append_jsonl(path: Path, line: str) -> None:
     """Append a single JSONL line under an exclusive fcntl lock.
 
@@ -264,7 +283,7 @@ class JournalStore:
             elif t == "msg":
                 messages.append({
                     "role": entry["role"],
-                    "content": entry["content"],
+                    "content": tag_message_content(entry["content"], entry.get("task_id")),
                 })
         record_journal_replay(
             target="parent",

--- a/src/agentlings/core/task.py
+++ b/src/agentlings/core/task.py
@@ -43,7 +43,7 @@ from agentlings.core.models import (
 )
 from agentlings.core.prompt import build_system_prompt
 from agentlings.core.skills import SkillRef
-from agentlings.core.store import JournalStore, TaskJournal
+from agentlings.core.store import JournalStore, TaskJournal, tag_message_content
 from agentlings.core.telemetry import (
     attach_context,
     capture_context,
@@ -478,7 +478,10 @@ class TaskWorker:
         messages = list(self._store.replay(record.context_id))
         messages.append({
             "role": "user",
-            "content": [{"type": "text", "text": record.message}],
+            "content": tag_message_content(
+                [{"type": "text", "text": record.message}],
+                record.task_id,
+            ),
         })
 
         memory = self._memory_store.load() if self._memory_store else None

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -138,6 +138,41 @@ class TestDataDirAwareness:
         for block in prompt:
             assert block.get("cache_control") == {"type": "ephemeral"}
 
+    def test_block_describes_actual_layout(
+        self, test_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        """The block must describe the v2 per-context layout, not the legacy flat one."""
+        prompt = build_system_prompt(test_config, data_dir=tmp_data_dir)
+        text = _all_text(prompt)
+        assert "<context_id>/journal.jsonl" in text
+        assert "<context_id>/tasks/<task_id>.jsonl" in text
+
+    def test_block_explains_task_tag_prefix(
+        self, test_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        """The block must tell the agent what ``[task <id>]`` prefixes mean."""
+        prompt = build_system_prompt(test_config, data_dir=tmp_data_dir)
+        text = _all_text(prompt)
+        assert "[task <id>]" in text
+
+    def test_block_teaches_bounded_inspection(
+        self, test_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        """The block must steer the agent toward bounded reads, not ``cat``."""
+        prompt = build_system_prompt(test_config, data_dir=tmp_data_dir)
+        text = _all_text(prompt)
+        assert "tail -n" in text
+        assert "Never ``cat``" in text or "Never `cat`" in text or "Never cat" in text
+
+    def test_block_lists_terminal_markers(
+        self, test_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        prompt = build_system_prompt(test_config, data_dir=tmp_data_dir)
+        text = _all_text(prompt)
+        assert "task_done" in text
+        assert "task_fail" in text
+        assert "task_cancel" in text
+
 
 class TestPromptBlockOrdering:
     """Blocks appear in a consistent order: skills, identity, memory, data dir."""

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -15,7 +15,12 @@ from agentlings.core.models import (
     TaskFailed,
     TaskStarted,
 )
-from agentlings.core.store import ContextNotFoundError, JournalStore, TaskJournal
+from agentlings.core.store import (
+    ContextNotFoundError,
+    JournalStore,
+    TaskJournal,
+    tag_message_content,
+)
 
 
 @pytest.fixture
@@ -362,11 +367,140 @@ class TestReplayFiltersAuditMarkers:
 
         messages = store.replay("ctx-1")
         # From the latest compaction onwards: compaction, user, assistant.
-        # Audit markers for t2 and t3 are stripped.
+        # Audit markers for t2 and t3 are stripped. Merged-back messages
+        # carry their task_id, so replay prepends a ``[task t3]`` tag block.
         assert [m["role"] for m in messages] == ["assistant", "user", "assistant"]
         assert messages[0]["content"] == "summary"
-        assert messages[1]["content"] == [{"type": "text", "text": "new"}]
-        assert messages[2]["content"] == [{"type": "text", "text": "ack"}]
+        assert messages[1]["content"] == [
+            {"type": "text", "text": "[task t3]"},
+            {"type": "text", "text": "new"},
+        ]
+        assert messages[2]["content"] == [
+            {"type": "text", "text": "[task t3]"},
+            {"type": "text", "text": "ack"},
+        ]
+
+
+class TestTaskIdTagging:
+    """Replay surfaces each message's task_id as a leading ``[task <id>]`` block.
+
+    The tag is what lets the LLM correlate a conversation turn with the
+    sub-journal that produced it — without it, the parent journal's user/
+    assistant pairs are anonymous and the agent has no way to recover what
+    tools were actually called inside a given turn.
+    """
+
+    def test_helper_no_tag_when_task_id_missing(self) -> None:
+        content = [{"type": "text", "text": "hi"}]
+        assert tag_message_content(content, None) == content
+
+    def test_helper_no_tag_when_task_id_empty_string(self) -> None:
+        content = [{"type": "text", "text": "hi"}]
+        assert tag_message_content(content, "") == content
+
+    def test_helper_prepends_tag_block(self) -> None:
+        original = [{"type": "text", "text": "hi"}]
+        tagged = tag_message_content(original, "abc-123")
+        assert tagged == [
+            {"type": "text", "text": "[task abc-123]"},
+            {"type": "text", "text": "hi"},
+        ]
+
+    def test_helper_does_not_mutate_input(self) -> None:
+        original = [{"type": "text", "text": "hi"}]
+        tag_message_content(original, "abc-123")
+        assert original == [{"type": "text", "text": "hi"}]
+
+    def test_replay_tags_user_message_with_task_id(
+        self, store: JournalStore
+    ) -> None:
+        store.create("ctx-1")
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="user",
+                content=[{"type": "text", "text": "upgrade grafana"}],
+                task_id="task-abc",
+            ),
+        )
+        messages = store.replay("ctx-1")
+        assert messages[0]["content"] == [
+            {"type": "text", "text": "[task task-abc]"},
+            {"type": "text", "text": "upgrade grafana"},
+        ]
+
+    def test_replay_tags_assistant_message_with_task_id(
+        self, store: JournalStore
+    ) -> None:
+        store.create("ctx-1")
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="assistant",
+                content=[{"type": "text", "text": "done"}],
+                task_id="task-abc",
+            ),
+        )
+        messages = store.replay("ctx-1")
+        assert messages[0]["content"] == [
+            {"type": "text", "text": "[task task-abc]"},
+            {"type": "text", "text": "done"},
+        ]
+
+    def test_replay_skips_tag_when_task_id_is_none(
+        self, store: JournalStore
+    ) -> None:
+        """Pre-task-era journal entries (no task_id) replay verbatim."""
+        store.create("ctx-1")
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="user",
+                content=[{"type": "text", "text": "untagged"}],
+            ),
+        )
+        messages = store.replay("ctx-1")
+        assert messages[0]["content"] == [{"type": "text", "text": "untagged"}]
+
+    def test_replay_tags_each_task_independently(
+        self, store: JournalStore
+    ) -> None:
+        """Different turns from different tasks each carry their own tag."""
+        store.create("ctx-1")
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="user",
+                content=[{"type": "text", "text": "first"}],
+                task_id="task-1",
+            ),
+        )
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="assistant",
+                content=[{"type": "text", "text": "one"}],
+                task_id="task-1",
+            ),
+        )
+        store.append(
+            "ctx-1",
+            MessageEntry(
+                ctx="ctx-1",
+                role="user",
+                content=[{"type": "text", "text": "second"}],
+                task_id="task-2",
+            ),
+        )
+        messages = store.replay("ctx-1")
+        assert messages[0]["content"][0]["text"] == "[task task-1]"
+        assert messages[1]["content"][0]["text"] == "[task task-1]"
+        assert messages[2]["content"][0]["text"] == "[task task-2]"
 
 
 class TestIterContextIds:

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -254,6 +254,91 @@ class TestSpawnFastPath:
         assert engine.registry.active_count() == 0
 
 
+class TestCurrentMessageTagging:
+    """The in-flight user message is tagged with the current task's id.
+
+    Without this, the model can see ``[task <id>]`` tags on every prior
+    turn from replay but has no anchor for the message it's responding to
+    right now. Tagging the current turn closes the loop so self-reference
+    works without extra prompting.
+    """
+
+    async def test_current_user_message_carries_task_tag(
+        self, tmp_data_dir: Path, test_config: AgentConfig
+    ) -> None:
+        captured: list[list[dict[str, Any]]] = []
+
+        class CapturingLLM(ControllableLLM):
+            async def complete(self, system, messages, tools, output_schema=None):  # noqa: ANN001
+                captured.append([dict(m) for m in messages])
+                return await super().complete(system, messages, tools, output_schema)
+
+        llm = CapturingLLM()
+        store = JournalStore(tmp_data_dir)
+        tools = ToolRegistry()
+        engine = TaskEngine(config=test_config, store=store, llm=llm, tools=tools)
+
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "ok"}],
+            stop_reason="end_turn",
+        ))
+        state = await engine.spawn("upgrade grafana")
+
+        assert state.status == TaskStatus.COMPLETED
+        assert captured, "LLM was never called"
+        last_user = captured[0][-1]
+        assert last_user["role"] == "user"
+        assert last_user["content"] == [
+            {"type": "text", "text": f"[task {state.task_id}]"},
+            {"type": "text", "text": "upgrade grafana"},
+        ]
+
+    async def test_subsequent_task_sees_prior_turn_tagged_with_prior_task_id(
+        self, tmp_data_dir: Path, test_config: AgentConfig
+    ) -> None:
+        """A new task replays the merged-back prior turn, tagged with its task_id."""
+        captured: list[list[dict[str, Any]]] = []
+
+        class CapturingLLM(ControllableLLM):
+            async def complete(self, system, messages, tools, output_schema=None):  # noqa: ANN001
+                captured.append([dict(m) for m in messages])
+                return await super().complete(system, messages, tools, output_schema)
+
+        llm = CapturingLLM()
+        store = JournalStore(tmp_data_dir)
+        tools = ToolRegistry()
+        engine = TaskEngine(config=test_config, store=store, llm=llm, tools=tools)
+
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "done"}],
+            stop_reason="end_turn",
+        ))
+        first = await engine.spawn("first request", context_id="ctx-shared")
+
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "ack"}],
+            stop_reason="end_turn",
+        ))
+        second = await engine.spawn("second request", context_id="ctx-shared")
+
+        # On the second call, the replay should contain the first task's
+        # merged-back user + assistant turns, each carrying ``[task <first.id>]``.
+        second_messages = captured[1]
+        # Filter to messages that came from replay (everything except the
+        # final fresh user message).
+        replayed = second_messages[:-1]
+        first_tag_block = {"type": "text", "text": f"[task {first.task_id}]"}
+        assert any(
+            isinstance(m["content"], list) and first_tag_block in m["content"]
+            for m in replayed
+        ), f"prior task tag not found in replay: {replayed}"
+        # And the current message carries the new task id.
+        assert second_messages[-1]["content"][0] == {
+            "type": "text",
+            "text": f"[task {second.task_id}]",
+        }
+
+
 # --------------------------------------------------------------------------- #
 # Engine: spawn + slow path (timeout yields working handle)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
The agent had no way to know its own `task_id` mid-conversation. The value sat in journal metadata but never reached the LLM — so retrospective questions ("what did you actually do in that prior turn?") had no anchor, and the agent couldn't correlate any merged-back conversation turn to the sub-journal that produced it.

- `JournalStore.replay()` prepends a `[task <id>]` text block to each `MessageEntry` whose `task_id` is set. Pre-task-era entries replay unchanged.
- `TaskWorker._run_inner` tags the in-flight user message before appending it to the LLM message list, so the current task is anchored as well.
- `DEFAULT_DATA_DIR_AWARENESS` rewritten to match the real v2 per-context layout (`<context_id>/journal.jsonl`, `<context_id>/tasks/<task_id>.jsonl`), explain what `[task <id>]` means, and teach bounded `tail`/`jq` inspection of sub-journals with an explicit "never cat" rule.
- Bump 0.6.1 → 0.7.0.

No new tools, no new system-prompt blocks, no per-task cache invalidation. The metadata lives where the LLM actually sees it.