### PR TITLE
feat: stamp agentling identity headers on every LLM request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.7.0"
+version = "0.8.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/__main__.py
+++ b/src/agentlings/__main__.py
@@ -226,6 +226,7 @@ def _sleep_command(date_str: str | None) -> None:
         model=config.agent_model,
         max_tokens=config.agent_max_tokens,
         base_url=config.anthropic_base_url,
+        agent_name=config.agent_name if config.definition.send_name_header else None,
     )
 
     cycle = SleepCycle(

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -115,6 +115,11 @@ class AgentDefinition(BaseModel):
             to read journals and conversation logs. Set to ``False`` for
             agents without filesystem tools or when the prompt budget is
             tight (e.g. small local models).
+        send_name_header: When ``True`` (default), send the agentling's ``name``
+            as the ``x-agentling-name`` header on every LLM request so a
+            deployment can attribute upstream traffic to a specific agentling.
+            Set to ``False`` to omit it (e.g. when a shared proxy injects its
+            own identity header).
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -126,6 +131,7 @@ class AgentDefinition(BaseModel):
     system_prompt: str | None = None
     bash_timeout: int = Field(ge=1, default=30)
     data_dir_awareness: bool = True
+    send_name_header: bool = True
     memory: MemoryConfig | None = None
     sleep: SleepConfig | None = None
     telemetry: TelemetryConfig | None = None

--- a/src/agentlings/core/completion.py
+++ b/src/agentlings/core/completion.py
@@ -96,6 +96,8 @@ async def run_completion(
     tools: ToolRegistry,
     turn_callback: Callable[[CompletionTurn], Awaitable[None]] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    context_id: str | None = None,
+    task_id: str | None = None,
 ) -> CompletionResult:
     """Run the LLM in a loop, executing tool calls until a terminal text response.
 
@@ -116,6 +118,10 @@ async def run_completion(
             ``CancellationRequested`` is raised and all partial progress so
             far is available in ``CompletionResult`` via a raised exception
             attribute.
+        context_id: The conversation this cycle belongs to. Forwarded to every
+            ``llm.complete`` call so each request carries the session header.
+        task_id: The task execution this cycle belongs to. Forwarded to every
+            ``llm.complete`` call so each request carries the task header.
 
     Returns:
         The final response content and all intermediate responses.
@@ -166,7 +172,10 @@ async def run_completion(
             turn_number = len(turns) + 1
 
             with otel_span("agentling.completion.llm_call", {"completion.turn": turn_number}) as llm_span:
-                response = await llm.complete(system, messages, tool_schemas)
+                response = await llm.complete(
+                    system, messages, tool_schemas,
+                    context_id=context_id, task_id=task_id,
+                )
                 _accumulate_usage(response)
                 usage = response.usage or {}
                 llm_span.set_attribute("llm.input_tokens", int(usage.get("input_tokens", 0) or 0))

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 
 BATCH_MAX_REQUESTS = 100_000
 
+# Headers stamped on every per-context LLM request so backends and proxies can
+# correlate a sequence of Messages calls back to a single agentling session
+# (context) and the specific task execution that fanned them out. The name
+# header is static for the process and is set once as a default header on the
+# client, rather than threaded per request.
+CONTEXT_ID_HEADER = "x-agentling-context-id"
+TASK_ID_HEADER = "x-agentling-task-id"
+NAME_HEADER = "x-agentling-name"
+
 # Matches ``delay-<seconds>`` in mock user messages — used by integration
 # tests to produce genuinely slow responses without global configuration.
 # Example: ``"delay-5 please answer"`` sleeps 5 seconds before responding.
@@ -108,6 +117,8 @@ class BaseLLMClient(ABC):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         output_schema: dict[str, Any] | None = None,
+        context_id: str | None = None,
+        task_id: str | None = None,
     ) -> LLMResponse:
         """Send a completion request and return the full response.
 
@@ -117,6 +128,13 @@ class BaseLLMClient(ABC):
             tools: Tool schemas available to the model.
             output_schema: JSON Schema for structured output. When provided,
                 the model is constrained to return valid JSON matching this schema.
+            context_id: The conversation this request belongs to. When set, it is
+                forwarded as the ``x-agentling-context-id`` request header so a
+                session can be tracked across the multiple Messages calls one task
+                fans out into.
+            task_id: The task execution this request belongs to. When set, it is
+                forwarded as the ``x-agentling-task-id`` request header so a single
+                task's Messages calls can be isolated within a session.
 
         Returns:
             The model's response content and stop reason.
@@ -209,15 +227,21 @@ class AnthropicLLMClient(BaseLLMClient):
         model: str,
         max_tokens: int,
         base_url: str | None = None,
+        agent_name: str | None = None,
     ) -> None:
         import anthropic
 
         client_kwargs: dict[str, Any] = {"api_key": api_key or "unset"}
         if base_url:
             client_kwargs["base_url"] = base_url
+        # The agentling name is constant for the process, so bake it into the
+        # client's default headers once rather than passing it on every call.
+        if agent_name:
+            client_kwargs["default_headers"] = {NAME_HEADER: agent_name}
         self._client = anthropic.AsyncAnthropic(**client_kwargs)
         self._model = model
         self._max_tokens = max_tokens
+        self._agent_name = agent_name
 
     async def complete(
         self,
@@ -225,6 +249,8 @@ class AnthropicLLMClient(BaseLLMClient):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         output_schema: dict[str, Any] | None = None,
+        context_id: str | None = None,
+        task_id: str | None = None,
     ) -> LLMResponse:
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -241,6 +267,13 @@ class AnthropicLLMClient(BaseLLMClient):
                     "schema": output_schema,
                 }
             }
+        extra_headers: dict[str, str] = {}
+        if context_id:
+            extra_headers[CONTEXT_ID_HEADER] = context_id
+        if task_id:
+            extra_headers[TASK_ID_HEADER] = task_id
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
 
         with otel_span("agentling.llm.complete", {
             "llm.backend": "anthropic",
@@ -249,6 +282,8 @@ class AnthropicLLMClient(BaseLLMClient):
             "llm.message_count": len(messages),
             "llm.tool_count": len(tools or []),
             "llm.has_output_schema": bool(output_schema),
+            "llm.context_id": context_id or "",
+            "llm.task_id": task_id or "",
         }) as span:
             start = time.monotonic()
             response = await self._client.messages.create(**kwargs)
@@ -420,6 +455,8 @@ class MockLLMClient(BaseLLMClient):
         self._compaction_threshold = compaction_threshold
         self._call_count = 0
         self._batch_store: dict[str, list[BatchRequest]] = {}
+        self.last_context_id: str | None = None
+        self.last_task_id: str | None = None
 
     async def complete(
         self,
@@ -427,8 +464,12 @@ class MockLLMClient(BaseLLMClient):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         output_schema: dict[str, Any] | None = None,
+        context_id: str | None = None,
+        task_id: str | None = None,
     ) -> LLMResponse:
         self._call_count += 1
+        self.last_context_id = context_id
+        self.last_task_id = task_id
         last_message = messages[-1] if messages else {}
         last_text = _extract_text(last_message)
 
@@ -453,6 +494,8 @@ class MockLLMClient(BaseLLMClient):
             "llm.model": self.MOCK_MODEL,
             "llm.message_count": len(messages),
             "llm.tool_count": len(tools or []),
+            "llm.context_id": context_id or "",
+            "llm.task_id": task_id or "",
         }) as span:
             if last_message.get("role") == "tool":
                 response = LLMResponse(
@@ -547,6 +590,7 @@ def create_llm_client(
     max_tokens: int = 4096,
     tool_names: list[str] | None = None,
     base_url: str | None = None,
+    agent_name: str | None = None,
 ) -> BaseLLMClient:
     """Factory that returns the appropriate LLM client for the given backend.
 
@@ -560,6 +604,9 @@ def create_llm_client(
         tool_names: Tool names the mock backend should recognize.
         base_url: Optional override for the Anthropic Messages endpoint.
             When set, the client talks to that URL instead of api.anthropic.com.
+        agent_name: When set, sent as the ``x-agentling-name`` default header on
+            every request so a deployment can attribute LLM traffic to a specific
+            agentling. Ignored by the mock backend (it makes no HTTP calls).
 
     Returns:
         A configured LLM client instance.
@@ -573,7 +620,11 @@ def create_llm_client(
     else:
         logger.info("using Anthropic LLM backend (model=%s)", model)
     return AnthropicLLMClient(
-        api_key=api_key, model=model, max_tokens=max_tokens, base_url=base_url,
+        api_key=api_key,
+        model=model,
+        max_tokens=max_tokens,
+        base_url=base_url,
+        agent_name=agent_name,
     )
 
 

--- a/src/agentlings/core/task.py
+++ b/src/agentlings/core/task.py
@@ -525,6 +525,8 @@ class TaskWorker:
             tools=self._tools,
             turn_callback=_on_turn,
             should_cancel=lambda: record.cancel_flag,
+            context_id=record.context_id,
+            task_id=record.task_id,
         )
         # Stash so ``run`` can stamp the cycle's token totals onto the
         # worker span before exiting.

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -170,6 +170,7 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         max_tokens=config.agent_max_tokens,
         tool_names=tools.tool_names(),
         base_url=config.anthropic_base_url,
+        agent_name=config.agent_name if config.definition.send_name_header else None,
     )
 
     skills = discover_skills(config.skills_dir) if config.skills_dir else []

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -65,6 +65,9 @@ class _OneShotToolLLM(MockLLMClient):
         system: list[dict[str, Any]],
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
+        output_schema: dict[str, Any] | None = None,
+        context_id: str | None = None,
+        task_id: str | None = None,
     ) -> LLMResponse:
         if not self._called:
             self._called = True
@@ -111,6 +114,26 @@ class TestRunCompletion:
         original_len = len(messages)
         await run_completion(llm, [], messages, tools)
         assert len(messages) > original_len
+
+    async def test_context_and_task_id_forwarded_to_every_turn(self, tools: ToolRegistry) -> None:
+        """A multi-turn cycle must stamp the session + task headers on each LLM call."""
+
+        class _RecordingLLM(MockLLMClient):
+            def __init__(self) -> None:
+                super().__init__(tool_names=["bash"])
+                self.seen: list[tuple[str | None, str | None]] = []
+
+            async def complete(self, system, messages, tools, output_schema=None, context_id=None, task_id=None):  # noqa: ANN001
+                self.seen.append((context_id, task_id))
+                return await super().complete(
+                    system, messages, tools, output_schema, context_id, task_id,
+                )
+
+        llm = _RecordingLLM()
+        messages = [{"role": "user", "content": [{"type": "text", "text": "run bash please"}]}]
+        await run_completion(llm, [], messages, tools, context_id="ctx-123", task_id="task-abc")
+        assert len(llm.seen) >= 2
+        assert all(seen == ("ctx-123", "task-abc") for seen in llm.seen)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -6,7 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from agentlings.core.llm import AnthropicLLMClient, MockLLMClient, create_llm_client
+from agentlings.core.llm import (
+    CONTEXT_ID_HEADER,
+    NAME_HEADER,
+    TASK_ID_HEADER,
+    AnthropicLLMClient,
+    MockLLMClient,
+    create_llm_client,
+)
 
 
 class TestMockLLMClient:
@@ -110,6 +117,92 @@ class TestAnthropicBatchResults:
         assert results[1].custom_id == "ctx-2"
         assert results[1].status == "failed"
         assert results[1].error == "rate limit"
+
+
+class TestContextIdHeader:
+    """The ``x-agentling-context-id`` header lets a backend correlate the
+    fan-out of Messages calls one task makes back to a single session.
+    """
+
+    def _stub_client(self) -> tuple[AnthropicLLMClient, AsyncMock]:
+        response = MagicMock()
+        response.content = []
+        response.stop_reason = "end_turn"
+        response.usage = None
+        create = AsyncMock(return_value=response)
+        mock_client = MagicMock()
+        mock_client.messages.create = create
+
+        client = AnthropicLLMClient.__new__(AnthropicLLMClient)
+        client._client = mock_client
+        client._model = "claude-sonnet-4-6"
+        client._max_tokens = 128
+        return client, create
+
+    @pytest.mark.asyncio
+    async def test_context_and_task_id_forwarded_as_headers(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(
+            system=[], messages=[], tools=[],
+            context_id="ctx-abc", task_id="task-123",
+        )
+
+        create.assert_awaited_once()
+        extra_headers = create.await_args.kwargs["extra_headers"]
+        assert extra_headers == {
+            CONTEXT_ID_HEADER: "ctx-abc",
+            TASK_ID_HEADER: "task-123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_only_provided_ids_become_headers(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(system=[], messages=[], tools=[], task_id="task-only")
+
+        extra_headers = create.await_args.kwargs["extra_headers"]
+        assert extra_headers == {TASK_ID_HEADER: "task-only"}
+
+    @pytest.mark.asyncio
+    async def test_no_header_when_ids_absent(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(system=[], messages=[], tools=[])
+
+        assert "extra_headers" not in create.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_mock_records_last_context_and_task_id(self) -> None:
+        client = MockLLMClient()
+        await client.complete(
+            system=[],
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            tools=[],
+            context_id="ctx-xyz",
+            task_id="task-xyz",
+        )
+        assert client.last_context_id == "ctx-xyz"
+        assert client.last_task_id == "task-xyz"
+
+
+class TestNameHeader:
+    """The static ``x-agentling-name`` header is baked into the client's
+    default headers once, so every request attributes traffic to the agentling
+    without per-call threading.
+    """
+
+    def test_name_set_as_default_header(self) -> None:
+        client = create_llm_client(
+            backend="anthropic", api_key="sk-test", agent_name="office-k3s",
+        )
+        assert isinstance(client, AnthropicLLMClient)
+        assert client._client.default_headers[NAME_HEADER] == "office-k3s"
+
+    def test_no_name_header_when_unset(self) -> None:
+        client = create_llm_client(backend="anthropic", api_key="sk-test")
+        assert isinstance(client, AnthropicLLMClient)
+        assert NAME_HEADER not in client._client.default_headers
 
 
 class TestFactory:

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -77,7 +77,7 @@ class ControllableLLM(BaseLLMClient):
     def push_exception(self, exc: Exception) -> None:
         self._queue.put_nowait(exc)
 
-    async def complete(self, system, messages, tools, output_schema=None) -> LLMResponse:  # noqa: ANN001
+    async def complete(self, system, messages, tools, output_schema=None, context_id=None, task_id=None) -> LLMResponse:  # noqa: ANN001
         self.call_count += 1
         self.before_call_event.set()
         item = await self._queue.get()
@@ -269,7 +269,7 @@ class TestCurrentMessageTagging:
         captured: list[list[dict[str, Any]]] = []
 
         class CapturingLLM(ControllableLLM):
-            async def complete(self, system, messages, tools, output_schema=None):  # noqa: ANN001
+            async def complete(self, system, messages, tools, output_schema=None, context_id=None, task_id=None):  # noqa: ANN001
                 captured.append([dict(m) for m in messages])
                 return await super().complete(system, messages, tools, output_schema)
 
@@ -300,7 +300,7 @@ class TestCurrentMessageTagging:
         captured: list[list[dict[str, Any]]] = []
 
         class CapturingLLM(ControllableLLM):
-            async def complete(self, system, messages, tools, output_schema=None):  # noqa: ANN001
+            async def complete(self, system, messages, tools, output_schema=None, context_id=None, task_id=None):  # noqa: ANN001
                 captured.append([dict(m) for m in messages])
                 return await super().complete(system, messages, tools, output_schema)
 


### PR DESCRIPTION
So upstream LLM traffic can be attributed to a specific agentling, conversation, and task execution for observability.

- Send `x-agentling-context-id` and `x-agentling-task-id` on every Messages request. These vary per call, so they ride as per-request `extra_headers`, threaded through `run_completion` from the task worker.
- Send `x-agentling-name`. This is static for the process, so it's baked once into the `AsyncAnthropic` client's `default_headers` rather than passed down per call — no per-request threading.
- Add `AgentDefinition.send_name_header` (default `true`) to suppress the name header, e.g. when a shared proxy injects its own identity. Mirrors the existing `data_dir_awareness` toggle.
- Bump version to 0.8.0.