### PR TITLE
fix: don't abort the sleep cycle when batch results retrieval fails (0.8.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.8.0"
+version = "0.8.1"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/sleep.py
+++ b/src/agentlings/core/sleep.py
@@ -339,7 +339,7 @@ class SleepCycle:
         while time.monotonic() < deadline:
             status = await self._llm.batch_status(batch_id)
             if status.processing_status == "ended":
-                return await self._llm.batch_results(batch_id)
+                return await self._fetch_results(batch_id)
             logger.debug(
                 "[SLEEP:DEEP] Batch %s: %s (next poll in %.0fs)",
                 batch_id, status.processing_status, interval,
@@ -348,9 +348,25 @@ class SleepCycle:
             interval = min(interval * 2, max_interval)
 
         logger.warning("[SLEEP:DEEP] Batch %s timed out after %.0fs", batch_id, timeout)
+        return await self._fetch_results(batch_id)
+
+    async def _fetch_results(self, batch_id: str) -> list[Any]:
+        """Retrieve batch results, degrading to ``[]`` on any failure.
+
+        A failure here must not abort the sleep cycle. The known case is the
+        gateway handing back a ``results_url`` that points straight at the
+        upstream API (bypassing the gateway's auth), so the SDK's results fetch
+        401s — but any transient error is treated the same way. We log loudly
+        and skip this batch's summaries so the run can still consolidate memory
+        and run housekeeping rather than crashing.
+        """
         try:
             return await self._llm.batch_results(batch_id)
         except Exception:
+            logger.exception(
+                "[SLEEP:DEEP] Failed to retrieve results for batch %s; "
+                "skipping this batch", batch_id,
+            )
             return []
 
     def _write_journal(self, date_str: str, content: str) -> None:

--- a/tests/unit/test_sleep.py
+++ b/tests/unit/test_sleep.py
@@ -196,3 +196,57 @@ class TestFullCycle:
         cycle, _, memory, _ = sleep_deps
         await cycle.run()
         assert memory.list() == []
+
+
+class _ResultsFailLLM(MockLLMClient):
+    """Batch completes (status=ended) but fetching results always fails.
+
+    Reproduces the sluice ``results_url`` failure: the batch object's
+    ``results_url`` points at ``api.anthropic.com`` (the real upstream), so the
+    SDK follows it directly, bypassing the gateway, and is rejected with a 401
+    ``invalid x-api-key``. The retrieval call raises; the cycle must not.
+    """
+
+    async def batch_results(self, batch_id: str):
+        raise RuntimeError("401 Unauthorized: invalid x-api-key")
+
+
+class TestBatchResultsResilience:
+    """A failure retrieving batch results must degrade gracefully rather than
+    abort the cycle (regression: the run aborted on the results 401)."""
+
+    async def test_poll_batch_swallows_results_failure(
+        self, sleep_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        store = JournalStore(tmp_data_dir)
+        memory = MemoryFileStore(tmp_data_dir)
+        llm = _ResultsFailLLM(tool_names=[])
+        cycle = SleepCycle(config=sleep_config, llm=llm, memory_store=memory, store=store)
+
+        # batch_status reports "ended", so _poll_batch takes the results path
+        # where batch_results raises. It must degrade to [] rather than propagate.
+        results = await cycle._poll_batch("mock_batch_x")
+        assert results == []
+
+    async def test_run_completes_when_results_fetch_fails(
+        self, sleep_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        store = JournalStore(tmp_data_dir)
+        memory = MemoryFileStore(tmp_data_dir)
+        llm = _ResultsFailLLM(tool_names=[])
+        cycle = SleepCycle(config=sleep_config, llm=llm, memory_store=memory, store=store)
+
+        # One conversation in the review window so deep_sleep submits a batch.
+        store.create("ctx-1")
+        store.append("ctx-1", MessageEntry(
+            ctx="ctx-1", role="user",
+            content=[{"type": "text", "text": "hello agent"}],
+        ))
+        path = tmp_data_dir / "ctx-1" / "journal.jsonl"
+        yesterday = datetime.now(timezone.utc) - timedelta(hours=12)
+        import os
+        os.utime(path, (yesterday.timestamp(), yesterday.timestamp()))
+
+        # Must complete without raising; with no results, memory stays untouched.
+        await cycle.run()
+        assert memory.list() == []


### PR DESCRIPTION
## Problem

The nightly sleep cycle fetches Message Batches results via the SDK. When LLM
traffic is routed through a gateway, the batch object's `results_url` comes
back pointing at the **upstream** API (`api.anthropic.com`), so the SDK follows
it directly — bypassing the gateway's auth — and gets a **401**.

`_poll_batch`'s completed-batch branch called `batch_results` **unguarded**, so
that 401 propagated all the way out of `SleepCycle.run()`:

- the one-off `agentling sleep` CLI **hard-crashed** (exit 1);
- the scheduled daemon didn't crash (`run_scheduler` wraps the callback in
  `try/except`) but the cycle still **aborted** before journal write, memory
  consolidation, and housekeeping — so the routine accomplished nothing nightly.

Observed in production: batch submitted + polled fine through the gateway, then
`GET api.anthropic.com/v1/messages/batches/{id}/results` → `401 invalid x-api-key`.

## Fix

Route both result fetches (completed **and** timed-out) through a guarded
`_fetch_results(batch_id)` helper that logs via `logger.exception` and returns
`[]` on any error. A single batch's retrieval failure now degrades to "no
summaries for that batch" and the cycle still consolidates memory and runs
housekeeping, instead of bailing.

This unifies behaviour with the timeout branch (which already swallowed errors)
and adds loud logging to both.

## Tests

`tests/unit/test_sleep.py::TestBatchResultsResilience`:
- `test_poll_batch_swallows_results_failure` — `_poll_batch` returns `[]` rather than raising.
- `test_run_completes_when_results_fetch_fails` — a full `run()` completes without raising.

Both fail on `main` (reproduce the crash) and pass with the fix. Full unit suite green.

## Note (operational)

This stops the abort but does **not** fix the gateway `results_url` passthrough —
results still 401, so summaries/memory stay empty until the gateway rewrites
`results_url` to point back at itself. Side effect of shipping this alone:
housekeeping now runs nightly, so conversations past the retention window will
be pruned even though they were never summarized. Pair with the gateway fix.

Releases **0.8.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)