### PR TITLE
fix: give REM memory consolidation a large output token budget (0.8.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.8.1"
+version = "0.8.2"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -49,6 +49,10 @@ class SleepConfig(BaseModel):
         model: Model override for sleep LLM calls (``None`` uses agent default).
         summary_prompt: Override for the per-conversation summary prompt.
         consolidation_prompt: Override for the REM consolidation prompt.
+        consolidation_max_tokens: Output token budget for the REM consolidation
+            call. Must be large enough to re-emit the entire memory (up to
+            ``memory_max_entries`` entries) as JSON; the per-turn agent default
+            (4096) truncates the response and the consolidation is dropped.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -61,6 +65,7 @@ class SleepConfig(BaseModel):
     model: str | None = None
     summary_prompt: str | None = None
     consolidation_prompt: str | None = None
+    consolidation_max_tokens: int = 16384
 
 
 class TelemetryConfig(BaseModel):

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -119,6 +119,7 @@ class BaseLLMClient(ABC):
         output_schema: dict[str, Any] | None = None,
         context_id: str | None = None,
         task_id: str | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         """Send a completion request and return the full response.
 
@@ -251,10 +252,12 @@ class AnthropicLLMClient(BaseLLMClient):
         output_schema: dict[str, Any] | None = None,
         context_id: str | None = None,
         task_id: str | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
+        effective_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
         kwargs: dict[str, Any] = {
             "model": self._model,
-            "max_tokens": self._max_tokens,
+            "max_tokens": effective_max_tokens,
             "system": system,
             "messages": messages,
         }
@@ -278,7 +281,7 @@ class AnthropicLLMClient(BaseLLMClient):
         with otel_span("agentling.llm.complete", {
             "llm.backend": "anthropic",
             "llm.model": self._model,
-            "llm.max_tokens": self._max_tokens,
+            "llm.max_tokens": effective_max_tokens,
             "llm.message_count": len(messages),
             "llm.tool_count": len(tools or []),
             "llm.has_output_schema": bool(output_schema),
@@ -457,6 +460,7 @@ class MockLLMClient(BaseLLMClient):
         self._batch_store: dict[str, list[BatchRequest]] = {}
         self.last_context_id: str | None = None
         self.last_task_id: str | None = None
+        self.last_max_tokens: int | None = None
 
     async def complete(
         self,
@@ -466,10 +470,12 @@ class MockLLMClient(BaseLLMClient):
         output_schema: dict[str, Any] | None = None,
         context_id: str | None = None,
         task_id: str | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         self._call_count += 1
         self.last_context_id = context_id
         self.last_task_id = task_id
+        self.last_max_tokens = max_tokens
         last_message = messages[-1] if messages else {}
         last_text = _extract_text(last_message)
 

--- a/src/agentlings/core/sleep.py
+++ b/src/agentlings/core/sleep.py
@@ -252,6 +252,7 @@ class SleepCycle:
             messages=[{"role": "user", "content": user_content}],
             tools=[],
             output_schema=strict_json_schema(ConsolidatedMemory),
+            max_tokens=self._sleep_config.consolidation_max_tokens,
         )
 
         text = self._extract_structured_text(response.content)

--- a/tests/unit/test_sleep.py
+++ b/tests/unit/test_sleep.py
@@ -250,3 +250,27 @@ class TestBatchResultsResilience:
         # Must complete without raising; with no results, memory stays untouched.
         await cycle.run()
         assert memory.list() == []
+
+
+class TestRemTokenBudget:
+    """REM consolidation must request enough output tokens to re-emit the full
+    memory. The 4096 default truncated the JSON mid-entry and the parse failed,
+    silently dropping the consolidation (regression)."""
+
+    async def test_rem_requests_consolidation_max_tokens(
+        self, sleep_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        store = JournalStore(tmp_data_dir)
+        memory = MemoryFileStore(tmp_data_dir)
+        llm = MockLLMClient(tool_names=[])
+        cycle = SleepCycle(config=sleep_config, llm=llm, memory_store=memory, store=store)
+
+        await cycle._rem(
+            summaries=["### ctx-1\na summary"], candidates=[], date_str="2026-05-26"
+        )
+
+        budget = (sleep_config.sleep_config or SleepConfig()).consolidation_max_tokens
+        assert budget >= 16384, "consolidation budget must be well above the 4096 default"
+        assert llm.last_max_tokens == budget, (
+            "REM must request the configured consolidation_max_tokens, not the default"
+        )


### PR DESCRIPTION
## Problem

With the sluice `results_url` fix in place, the nightly sleep cycle now retrieves
batch summaries fine — but **memory consolidation (REM) silently fails**. `_rem`
asks the model to re-emit the entire consolidated memory as one structured-output
JSON, using the per-turn agent default `max_tokens` (**4096**). Once memory holds
more than a handful of entries the response truncates:

```
[SLEEP:REM] Failed to parse consolidated memory: 1 validation error for ConsolidatedMemory
  Invalid JSON: EOF while parsing a string at line 1 column 13008 ...
```

So `memory.json` never updates, even though the daily journal is written.
Observed consolidating 28 existing + 33 candidates.

## Fix

- `complete()` gains an optional `max_tokens` override (Anthropic client uses it,
  falling back to the instance default; mock records it).
- `SleepConfig.consolidation_max_tokens` (default **16384**) — enough to re-emit
  up to `memory_max_entries` (50) entries; tunable via `agent.yaml`.
- `_rem` passes it.

Per-conversation summary batches are untouched (4096 is ample for a 2-3 sentence
summary); only the all-entries consolidation needed the headroom.

## Tests

`tests/unit/test_sleep.py::TestRemTokenBudget::test_rem_requests_consolidation_max_tokens`
asserts `_rem` calls `complete()` with the configured budget (≥16384), not the
4096 default. Fails on `main`, passes here. Full unit suite green.

Releases **0.8.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)