### PR TITLE
feat: configurable extended thinking + bash default 50s (0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,50 @@ A request flows top-to-bottom through this tree, parent → child:
 
 When telemetry is disabled (the default) or the OpenTelemetry packages are not installed, all instrumentation is a no-op — the cost is one function call per span/metric site.
 
+## Extended thinking
+
+Agentlings can be configured to let Claude do extended reasoning before its visible reply. Off by default. Three modes match the model-generation split that landed in Q1 2026:
+
+| Mode | When to use | YAML block |
+|------|-------------|------------|
+| `off` (default) | Non-Anthropic backends; cost-sensitive workloads | `thinking: { mode: "off" }` |
+| `adaptive` | Opus 4.6+, Sonnet 4.6+, Mythos Preview | `thinking: { mode: "adaptive", effort: "medium" }` |
+| `budget` | Sonnet 3.7 / 4 / 4.5, Opus 4 / 4.1 / 4.5, Haiku 4.5 | `thinking: { mode: "budget", budget_tokens: 4096, interleaved: true }` |
+
+### Adaptive mode (recommended on 4.6+)
+
+The model picks its own thinking budget per request. You control depth with the `effort` parameter (`low | medium | high | xhigh | max`). Interleaved thinking between tool calls is automatic — no flag needed. On Opus 4.7+ thinking content is hidden by default; set `display: "summarized"` to opt back in.
+
+```yaml
+thinking:
+  mode: adaptive
+  effort: medium
+  # display: summarized  # opt back into summarized thinking on Opus 4.7+
+```
+
+Required on Opus 4.7+. Recommended on Opus 4.6 and Sonnet 4.6 (where legacy `budget_tokens` is deprecated but still accepted).
+
+### Budget mode (legacy)
+
+Sets `thinking: {"type": "enabled", "budget_tokens": N}` on every Messages call. `budget_tokens` must be ≥ 1024 and (unless `interleaved: true`) less than `max_tokens`. Setting `interleaved: true` adds the `interleaved-thinking-2025-05-14` beta header so the model can think between tool calls; in that case the budget is a per-turn total and may exceed `max_tokens`.
+
+```yaml
+thinking:
+  mode: budget
+  budget_tokens: 4096
+  interleaved: true
+```
+
+Required on Sonnet 4 / 4.5, Opus 4 / 4.1 / 4.5, and Haiku 4.5 (which does not support interleaved). Rejected with HTTP 400 on Opus 4.7+.
+
+### Sleep cycle
+
+The sleep cycle's batch calls inherit the same thinking config. Interleaved thinking is silently dropped for batch calls (the batches API cannot carry a per-request beta header), but the thinking block itself is still sent.
+
+### Mock backend
+
+The mock backend ignores thinking for behaviour but records the config on the client (`MockLLMClient.thinking_config`) so tests can assert the wiring without an Anthropic key.
+
 ## Architecture
 
 ```mermaid

--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -34,6 +34,24 @@ sleep:
   # summary_prompt: null    # override per-conversation summary prompt
   # consolidation_prompt: null  # override REM consolidation prompt
 
+thinking:
+  # Extended thinking. Off by default.
+  #
+  # mode: "off" (default) — no thinking block sent.
+  # mode: "adaptive" — Opus 4.6+ / Sonnet 4.6+ shape. The model picks
+  #   its own thinking budget; control depth with `effort`. Interleaved
+  #   thinking between tool calls is automatic in this mode.
+  # mode: "budget" — legacy shape, supported on Sonnet 3.7,
+  #   Sonnet 4 / 4.5, Opus 4 / 4.1 / 4.5, and Haiku 4.5. Set
+  #   `interleaved: true` to think between tool calls (requires the
+  #   model to support the interleaved-thinking-2025-05-14 beta;
+  #   Haiku 4.5 does NOT).
+  mode: "off"
+  # effort: "medium"     # adaptive only: low | medium | high | xhigh | max
+  # display: "summarized"  # adaptive only: opts back into summarized thinking content on Opus 4.7+
+  # budget_tokens: 8192    # budget only: must be >= 1024 (and < max_tokens unless interleaved)
+  # interleaved: false     # budget only: adds the interleaved-thinking-2025-05-14 beta header
+
 telemetry:
   # Off by default. When enabled, the agent emits OTLP traces + metrics
   # for every HTTP request, protocol call, task, LLM call, tool, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.8.2"
+version = "0.9.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/__main__.py
+++ b/src/agentlings/__main__.py
@@ -227,6 +227,7 @@ def _sleep_command(date_str: str | None) -> None:
         max_tokens=config.agent_max_tokens,
         base_url=config.anthropic_base_url,
         agent_name=config.agent_name if config.definition.send_name_header else None,
+        thinking=config.definition.thinking,
     )
 
     cycle = SleepCycle(

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -68,6 +68,76 @@ class SleepConfig(BaseModel):
     consolidation_max_tokens: int = 16384
 
 
+ThinkingMode = Literal["off", "budget", "adaptive"]
+ThinkingEffort = Literal["low", "medium", "high", "xhigh", "max"]
+ThinkingDisplay = Literal["summarized"]
+
+INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14"
+
+
+class ThinkingConfig(BaseModel):
+    """Extended-thinking configuration for Anthropic models.
+
+    Three modes cover the model-generation split that landed in early 2026:
+
+    * ``mode: "off"`` (default) — no ``thinking`` block is attached. Use
+      this for non-Anthropic backends (Ollama) and for cost-sensitive
+      live calls.
+
+    * ``mode: "budget"`` — legacy shape, supported on Claude Sonnet 3.7,
+      Sonnet 4/4.5, Opus 4/4.1/4.5, and Haiku 4.5. Sends
+      ``thinking={"type": "enabled", "budget_tokens": N}``. Set
+      ``interleaved: true`` to add the ``interleaved-thinking-2025-05-14``
+      beta header (required on Opus 4-4.5 and Sonnet 4-4.5 to think
+      between tool calls; not supported on Haiku 4.5). Anthropic requires
+      ``budget_tokens >= 1024`` and ``< max_tokens`` (except when
+      ``interleaved: true``, where the budget is a per-turn total across
+      all thinking blocks and may exceed ``max_tokens``).
+
+    * ``mode: "adaptive"`` — the post-Sonnet-4.6 shape. Sends
+      ``thinking={"type": "adaptive"}`` and lets the model decide budget
+      per request. Required on Opus 4.7+ (legacy budget returns 400);
+      recommended on Sonnet 4.6 and Opus 4.6. Optional ``effort`` knob
+      (``low|medium|high|xhigh|max``) goes into ``output_config.effort``.
+      Optional ``display: "summarized"`` opts back into summarized
+      thinking content on Opus 4.7+ (default is empty thinking blocks).
+      Interleaved thinking is automatic in this mode — no flag needed.
+
+    A ``model_validator`` rejects combinations that the API would reject
+    (e.g. ``effort`` set when ``mode != "adaptive"``). The LLM client logs
+    a warning at construction if the configured mode looks wrong for the
+    active model, but does not refuse — the user may swap models without
+    re-validating YAML, and a clear log line is better than a startup
+    crash.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    mode: ThinkingMode = "off"
+    budget_tokens: int = Field(ge=1024, default=8192)
+    interleaved: bool = False
+    effort: ThinkingEffort | None = None
+    display: ThinkingDisplay | None = None
+
+    @model_validator(mode="after")
+    def _validate_mode_fields(self) -> "ThinkingConfig":
+        if self.mode != "adaptive":
+            if self.effort is not None:
+                raise ValueError(
+                    "thinking.effort is only valid when thinking.mode == 'adaptive'"
+                )
+            if self.display is not None:
+                raise ValueError(
+                    "thinking.display is only valid when thinking.mode == 'adaptive'"
+                )
+        if self.mode != "budget" and self.interleaved:
+            raise ValueError(
+                "thinking.interleaved is only valid when thinking.mode == 'budget' "
+                "(interleaved thinking is implicit on adaptive mode)"
+            )
+        return self
+
+
 class TelemetryConfig(BaseModel):
     """OpenTelemetry configuration.
 
@@ -134,12 +204,13 @@ class AgentDefinition(BaseModel):
     tools: list[str] = Field(default_factory=list)
     skills: list[SkillConfig] = Field(default_factory=list)
     system_prompt: str | None = None
-    bash_timeout: int = Field(ge=1, default=30)
+    bash_timeout: int = Field(ge=1, default=50)
     data_dir_awareness: bool = True
     send_name_header: bool = True
     memory: MemoryConfig | None = None
     sleep: SleepConfig | None = None
     telemetry: TelemetryConfig | None = None
+    thinking: ThinkingConfig | None = None
 
 
 class AgentConfig(BaseSettings):

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -11,11 +11,95 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Literal
 from uuid import uuid4
 
+from agentlings.config import INTERLEAVED_THINKING_BETA, ThinkingConfig
 from agentlings.core.telemetry import otel_span, record_llm_usage
 
 logger = logging.getLogger(__name__)
 
 BATCH_MAX_REQUESTS = 100_000
+
+# Anthropic-beta header name. Stacks comma-separated values when multiple
+# beta features are active on the same request.
+ANTHROPIC_BETA_HEADER = "anthropic-beta"
+
+
+def _build_thinking_kwargs(
+    thinking: ThinkingConfig | None,
+    max_tokens: int,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+    """Translate a ThinkingConfig into Anthropic Messages API kwargs.
+
+    Returns ``(thinking_block, output_config_addition, beta_header)`` where:
+
+    * ``thinking_block`` is the value for the ``thinking`` parameter, or
+      ``None`` when no block should be sent.
+    * ``output_config_addition`` is an ``output_config`` sub-dict to merge
+      (currently only carries ``effort`` in adaptive mode), or ``None``.
+    * ``beta_header`` is the value for the ``anthropic-beta`` header, or
+      ``None``. Caller is responsible for merging it with any other beta
+      values it may already be sending.
+
+    Budget mode self-protects: if ``budget_tokens`` would equal or exceed
+    ``max_tokens`` and interleaved mode is off (where the budget can
+    legally exceed max_tokens), the block is dropped and a warning is
+    logged. The conversation continues without thinking rather than 400-ing.
+    """
+    if thinking is None or thinking.mode == "off":
+        return None, None, None
+
+    if thinking.mode == "budget":
+        if not thinking.interleaved and thinking.budget_tokens >= max_tokens:
+            logger.warning(
+                "thinking.budget_tokens (%d) >= max_tokens (%d); "
+                "skipping thinking block for this call",
+                thinking.budget_tokens, max_tokens,
+            )
+            return None, None, None
+        block = {"type": "enabled", "budget_tokens": thinking.budget_tokens}
+        beta = INTERLEAVED_THINKING_BETA if thinking.interleaved else None
+        return block, None, beta
+
+    # adaptive
+    block: dict[str, Any] = {"type": "adaptive"}
+    if thinking.display is not None:
+        block["display"] = thinking.display
+    output_addition = {"effort": thinking.effort} if thinking.effort is not None else None
+    return block, output_addition, None
+
+
+# Crude model-family heuristics for the startup mismatch warning. The
+# matching is loose on purpose — Anthropic ships new models faster than
+# we can hardcode them, so we only flag the loudest known incompatibilities.
+_ADAPTIVE_ONLY_MODELS = ("claude-opus-4-7", "claude-opus-4-8", "claude-mythos")
+_LEGACY_BUDGET_MODELS = (
+    "claude-sonnet-3-7",
+    "claude-sonnet-4-",  # 4.0 / 4.1 / 4.5 (4.6+ accept budget but deprecated)
+    "claude-opus-4-0",
+    "claude-opus-4-1",
+    "claude-opus-4-5",
+    "claude-haiku-4-5",
+)
+
+
+def _warn_if_mode_mismatches_model(mode: str, model: str) -> None:
+    """Log a warning if the configured thinking mode is unlikely to work on the model.
+
+    Not a hard rejection — users routinely swap models without re-validating
+    YAML. A clear warning at startup is friendlier than a mysterious 400 on
+    the first call, but failing the daemon over a heuristic would be worse.
+    """
+    if mode == "budget" and any(model.startswith(m) for m in _ADAPTIVE_ONLY_MODELS):
+        logger.warning(
+            "thinking.mode='budget' on model %s — this model rejects "
+            "the legacy thinking shape with HTTP 400; switch to 'adaptive'",
+            model,
+        )
+    elif mode == "adaptive" and any(model.startswith(m) for m in _LEGACY_BUDGET_MODELS):
+        logger.warning(
+            "thinking.mode='adaptive' on model %s — this model does not "
+            "support adaptive thinking; switch to 'budget' or 'off'",
+            model,
+        )
 
 # Headers stamped on every per-context LLM request so backends and proxies can
 # correlate a sequence of Messages calls back to a single agentling session
@@ -229,6 +313,7 @@ class AnthropicLLMClient(BaseLLMClient):
         max_tokens: int,
         base_url: str | None = None,
         agent_name: str | None = None,
+        thinking: ThinkingConfig | None = None,
     ) -> None:
         import anthropic
 
@@ -243,6 +328,9 @@ class AnthropicLLMClient(BaseLLMClient):
         self._model = model
         self._max_tokens = max_tokens
         self._agent_name = agent_name
+        self._thinking = thinking if thinking is not None and thinking.mode != "off" else None
+        if self._thinking is not None:
+            _warn_if_mode_mismatches_model(self._thinking.mode, model)
 
     async def complete(
         self,
@@ -263,18 +351,29 @@ class AnthropicLLMClient(BaseLLMClient):
         }
         if tools:
             kwargs["tools"] = tools
+        output_config: dict[str, Any] = {}
         if output_schema:
-            kwargs["output_config"] = {
-                "format": {
-                    "type": "json_schema",
-                    "schema": output_schema,
-                }
+            output_config["format"] = {
+                "type": "json_schema",
+                "schema": output_schema,
             }
+        # __new__ stubs in tests bypass __init__, so _thinking may be unset.
+        thinking_block, output_addition, beta_header = _build_thinking_kwargs(
+            getattr(self, "_thinking", None), effective_max_tokens,
+        )
+        if thinking_block is not None:
+            kwargs["thinking"] = thinking_block
+        if output_addition:
+            output_config.update(output_addition)
+        if output_config:
+            kwargs["output_config"] = output_config
         extra_headers: dict[str, str] = {}
         if context_id:
             extra_headers[CONTEXT_ID_HEADER] = context_id
         if task_id:
             extra_headers[TASK_ID_HEADER] = task_id
+        if beta_header:
+            extra_headers[ANTHROPIC_BETA_HEADER] = beta_header
         if extra_headers:
             kwargs["extra_headers"] = extra_headers
 
@@ -346,6 +445,7 @@ class AnthropicLLMClient(BaseLLMClient):
             "llm.model": use_model,
             "llm.batch.request_count": len(requests),
         }) as span:
+            thinking_cfg = getattr(self, "_thinking", None)
             for i in range(0, len(requests), BATCH_MAX_REQUESTS):
                 chunk = requests[i : i + BATCH_MAX_REQUESTS]
                 api_requests = []
@@ -356,13 +456,26 @@ class AnthropicLLMClient(BaseLLMClient):
                         "system": req.system,
                         "messages": req.messages,
                     }
+                    output_config: dict[str, Any] = {}
                     if req.output_schema:
-                        params["output_config"] = {
-                            "format": {
-                                "type": "json_schema",
-                                "schema": req.output_schema,
-                            }
+                        output_config["format"] = {
+                            "type": "json_schema",
+                            "schema": req.output_schema,
                         }
+                    thinking_block, output_addition, _beta = _build_thinking_kwargs(
+                        thinking_cfg, req.max_tokens,
+                    )
+                    # batch_create cannot send a per-request beta header, so
+                    # interleaved thinking is incompatible with budget-mode
+                    # batches on older models. The block itself is still sent;
+                    # the lack of header means interleaving is off for older
+                    # models, but the call still succeeds.
+                    if thinking_block is not None:
+                        params["thinking"] = thinking_block
+                    if output_addition:
+                        output_config.update(output_addition)
+                    if output_config:
+                        params["output_config"] = output_config
                     api_requests.append(
                         Request(
                             custom_id=req.custom_id,
@@ -453,6 +566,7 @@ class MockLLMClient(BaseLLMClient):
         self,
         tool_names: list[str] | None = None,
         compaction_threshold: int = 10,
+        thinking: ThinkingConfig | None = None,
     ) -> None:
         self._tool_names = tool_names or []
         self._compaction_threshold = compaction_threshold
@@ -461,6 +575,11 @@ class MockLLMClient(BaseLLMClient):
         self.last_context_id: str | None = None
         self.last_task_id: str | None = None
         self.last_max_tokens: int | None = None
+        # Record the thinking config so tests can assert it was threaded
+        # through the factory. The mock backend ignores it for behavior.
+        self.thinking_config: ThinkingConfig | None = (
+            thinking if thinking is not None and thinking.mode != "off" else None
+        )
 
     async def complete(
         self,
@@ -597,6 +716,7 @@ def create_llm_client(
     tool_names: list[str] | None = None,
     base_url: str | None = None,
     agent_name: str | None = None,
+    thinking: ThinkingConfig | None = None,
 ) -> BaseLLMClient:
     """Factory that returns the appropriate LLM client for the given backend.
 
@@ -619,18 +739,27 @@ def create_llm_client(
     """
     if backend == "mock":
         logger.info("using mock LLM backend")
-        return MockLLMClient(tool_names=tool_names)
+        return MockLLMClient(tool_names=tool_names, thinking=thinking)
 
     if base_url:
         logger.info("using Anthropic-compatible LLM backend (model=%s, base_url=%s)", model, base_url)
     else:
         logger.info("using Anthropic LLM backend (model=%s)", model)
+    if thinking is not None and thinking.mode != "off":
+        logger.info(
+            "extended thinking enabled: mode=%s%s%s%s",
+            thinking.mode,
+            f", effort={thinking.effort}" if thinking.effort else "",
+            f", budget_tokens={thinking.budget_tokens}" if thinking.mode == "budget" else "",
+            ", interleaved=true" if thinking.interleaved else "",
+        )
     return AnthropicLLMClient(
         api_key=api_key,
         model=model,
         max_tokens=max_tokens,
         base_url=base_url,
         agent_name=agent_name,
+        thinking=thinking,
     )
 
 

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -171,6 +171,7 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         tool_names=tools.tool_names(),
         base_url=config.anthropic_base_url,
         agent_name=config.agent_name if config.definition.send_name_header else None,
+        thinking=config.definition.thinking,
     )
 
     skills = discover_skills(config.skills_dir) if config.skills_dir else []

--- a/src/agentlings/templates/default/agent.yaml
+++ b/src/agentlings/templates/default/agent.yaml
@@ -39,3 +39,10 @@ memory:
 sleep:
   enabled: true
   schedule: "0 2 * * *"
+
+thinking:
+  # Extended thinking. Off by default. See README for the full mode/effort
+  # matrix per model family.
+  mode: "off"
+  # mode: "adaptive"
+  # effort: "medium"

--- a/src/agentlings/tools/builtins.py
+++ b/src/agentlings/tools/builtins.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from agentlings.tools.registry import ToolResult
 
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 50
 
 
 # ---------------------------------------------------------------------------

--- a/src/agentlings/tools/registry.py
+++ b/src/agentlings/tools/registry.py
@@ -138,7 +138,7 @@ class ToolRegistry:
                 is_error=True,
             )
 
-    def register_tools(self, enabled: list[str], bash_timeout: int = 30) -> None:
+    def register_tools(self, enabled: list[str], bash_timeout: int = 50) -> None:
         """Register built-in tools by name or group.
 
         Args:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from agentlings.config import (
     SkillConfig,
     SleepConfig,
     TelemetryConfig,
+    ThinkingConfig,
 )
 
 
@@ -231,7 +232,7 @@ class TestAgentDefinition:
 
     def test_bash_timeout_default(self) -> None:
         defn = AgentDefinition()
-        assert defn.bash_timeout == 30
+        assert defn.bash_timeout == 50
 
     def test_bash_timeout_custom(self) -> None:
         defn = AgentDefinition(bash_timeout=120)
@@ -244,6 +245,54 @@ class TestAgentDefinition:
     def test_bash_timeout_negative_rejected(self) -> None:
         with pytest.raises(Exception):
             AgentDefinition(bash_timeout=-1)
+
+
+class TestThinkingConfig:
+    def test_defaults(self) -> None:
+        cfg = ThinkingConfig()
+        assert cfg.mode == "off"
+        assert cfg.budget_tokens == 8192
+        assert cfg.interleaved is False
+        assert cfg.effort is None
+        assert cfg.display is None
+
+    def test_budget_mode_with_interleaved(self) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=4096, interleaved=True)
+        assert cfg.mode == "budget"
+        assert cfg.interleaved is True
+
+    def test_adaptive_with_effort_and_display(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", effort="medium", display="summarized")
+        assert cfg.mode == "adaptive"
+        assert cfg.effort == "medium"
+        assert cfg.display == "summarized"
+
+    def test_budget_tokens_below_min_rejected(self) -> None:
+        with pytest.raises(Exception):
+            ThinkingConfig(mode="budget", budget_tokens=512)
+
+    def test_effort_only_valid_in_adaptive_mode(self) -> None:
+        with pytest.raises(Exception, match="adaptive"):
+            ThinkingConfig(mode="budget", effort="medium")
+
+    def test_display_only_valid_in_adaptive_mode(self) -> None:
+        with pytest.raises(Exception, match="adaptive"):
+            ThinkingConfig(mode="off", display="summarized")
+
+    def test_interleaved_only_valid_in_budget_mode(self) -> None:
+        with pytest.raises(Exception, match="budget"):
+            ThinkingConfig(mode="adaptive", interleaved=True)
+
+    def test_invalid_effort_value_rejected(self) -> None:
+        with pytest.raises(Exception):
+            ThinkingConfig(mode="adaptive", effort="ultra")
+
+    def test_agent_definition_thinking_optional(self) -> None:
+        defn = AgentDefinition()
+        assert defn.thinking is None
+        defn2 = AgentDefinition(thinking=ThinkingConfig(mode="adaptive", effort="medium"))
+        assert defn2.thinking is not None
+        assert defn2.thinking.mode == "adaptive"
 
 
 class TestMemoryConfig:

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -6,12 +6,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agentlings.config import INTERLEAVED_THINKING_BETA, ThinkingConfig
 from agentlings.core.llm import (
+    ANTHROPIC_BETA_HEADER,
     CONTEXT_ID_HEADER,
     NAME_HEADER,
     TASK_ID_HEADER,
     AnthropicLLMClient,
     MockLLMClient,
+    _build_thinking_kwargs,
     create_llm_client,
 )
 
@@ -247,6 +250,149 @@ class TestFactory:
             base_url="http://localhost:11434",
         )
         assert client._client.api_key == "unset"
+
+
+class TestThinkingHelper:
+    """``_build_thinking_kwargs`` translates ThinkingConfig → API kwargs.
+
+    These cover the three modes plus the budget>=max_tokens self-protection
+    path, without booting an HTTP client.
+    """
+
+    def test_off_returns_none_triple(self) -> None:
+        block, output, beta = _build_thinking_kwargs(None, max_tokens=4096)
+        assert (block, output, beta) == (None, None, None)
+        block, output, beta = _build_thinking_kwargs(
+            ThinkingConfig(mode="off"), max_tokens=4096,
+        )
+        assert (block, output, beta) == (None, None, None)
+
+    def test_budget_mode_emits_enabled_block(self) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=2048)
+        block, output, beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "enabled", "budget_tokens": 2048}
+        assert output is None
+        assert beta is None
+
+    def test_budget_mode_interleaved_adds_beta_header(self) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=2048, interleaved=True)
+        block, _output, beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "enabled", "budget_tokens": 2048}
+        assert beta == INTERLEAVED_THINKING_BETA
+
+    def test_budget_over_max_tokens_drops_block(self, caplog: pytest.LogCaptureFixture) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=8192)
+        with caplog.at_level("WARNING"):
+            block, _output, _beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block is None
+        assert any("budget_tokens" in r.message for r in caplog.records)
+
+    def test_interleaved_budget_may_exceed_max_tokens(self) -> None:
+        # With interleaved, the budget is a per-turn total across all
+        # thinking blocks and may legally exceed max_tokens.
+        cfg = ThinkingConfig(mode="budget", budget_tokens=8192, interleaved=True)
+        block, _output, beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "enabled", "budget_tokens": 8192}
+        assert beta == INTERLEAVED_THINKING_BETA
+
+    def test_adaptive_mode_emits_adaptive_block_with_effort(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", effort="medium")
+        block, output, beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "adaptive"}
+        assert output == {"effort": "medium"}
+        assert beta is None
+
+    def test_adaptive_mode_emits_display(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", display="summarized", effort="low")
+        block, _output, _beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "adaptive", "display": "summarized"}
+
+    def test_adaptive_without_effort_omits_output_addition(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive")
+        block, output, _beta = _build_thinking_kwargs(cfg, max_tokens=4096)
+        assert block == {"type": "adaptive"}
+        assert output is None
+
+
+class TestAnthropicClientThinkingIntegration:
+    """The client surfaces thinking via the right kwargs + headers."""
+
+    def _stub_client(self, thinking: ThinkingConfig | None = None) -> tuple[AnthropicLLMClient, AsyncMock]:
+        response = MagicMock()
+        response.content = []
+        response.stop_reason = "end_turn"
+        response.usage = None
+        create = AsyncMock(return_value=response)
+        mock_client = MagicMock()
+        mock_client.messages.create = create
+        client = AnthropicLLMClient.__new__(AnthropicLLMClient)
+        client._client = mock_client
+        client._model = "claude-sonnet-4-6"
+        client._max_tokens = 4096
+        client._thinking = thinking
+        return client, create
+
+    @pytest.mark.asyncio
+    async def test_adaptive_thinking_appears_in_kwargs(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", effort="medium")
+        client, create = self._stub_client(thinking=cfg)
+        await client.complete(system=[], messages=[], tools=[])
+        kwargs = create.await_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "medium"}
+        assert "extra_headers" not in kwargs or ANTHROPIC_BETA_HEADER not in kwargs.get(
+            "extra_headers", {}
+        )
+
+    @pytest.mark.asyncio
+    async def test_budget_interleaved_emits_block_plus_beta_header(self) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=2048, interleaved=True)
+        client, create = self._stub_client(thinking=cfg)
+        await client.complete(system=[], messages=[], tools=[])
+        kwargs = create.await_args.kwargs
+        assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+        assert kwargs["extra_headers"][ANTHROPIC_BETA_HEADER] == INTERLEAVED_THINKING_BETA
+
+    @pytest.mark.asyncio
+    async def test_no_thinking_when_unconfigured(self) -> None:
+        client, create = self._stub_client(thinking=None)
+        await client.complete(system=[], messages=[], tools=[])
+        kwargs = create.await_args.kwargs
+        assert "thinking" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_existing_output_schema_merges_with_effort(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", effort="high")
+        client, create = self._stub_client(thinking=cfg)
+        await client.complete(
+            system=[], messages=[], tools=[],
+            output_schema={"type": "object"},
+        )
+        oc = create.await_args.kwargs["output_config"]
+        assert oc["format"]["type"] == "json_schema"
+        assert oc["effort"] == "high"
+
+
+class TestThinkingFactory:
+    """The factory threads thinking through to whichever client it builds."""
+
+    def test_mock_backend_records_thinking(self) -> None:
+        cfg = ThinkingConfig(mode="adaptive", effort="medium")
+        client = create_llm_client(backend="mock", thinking=cfg)
+        assert isinstance(client, MockLLMClient)
+        assert client.thinking_config == cfg
+
+    def test_mock_backend_drops_off_mode(self) -> None:
+        client = create_llm_client(backend="mock", thinking=ThinkingConfig(mode="off"))
+        assert client.thinking_config is None  # type: ignore[union-attr]
+
+    def test_anthropic_backend_threads_thinking(self) -> None:
+        cfg = ThinkingConfig(mode="budget", budget_tokens=2048)
+        client = create_llm_client(
+            backend="anthropic", api_key="k", model="claude-sonnet-4-5",
+            max_tokens=4096, thinking=cfg,
+        )
+        assert client._thinking == cfg  # type: ignore[union-attr]
 
 
 class TestMockLLMDelay:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -276,7 +276,7 @@ class TestBashTimeout:
     def test_build_builtin_registry_default(self) -> None:
         reg = build_builtin_registry()
         assert "bash" in reg
-        assert "30" in reg["bash"]["input_schema"]["properties"]["timeout"]["description"]
+        assert "50" in reg["bash"]["input_schema"]["properties"]["timeout"]["description"]
 
     def test_build_builtin_registry_custom(self) -> None:
         reg = build_builtin_registry(bash_timeout=90)


### PR DESCRIPTION
## Summary

- Adds a `ThinkingConfig` sub-block to the agent YAML supporting three modes (`off` / `adaptive` / `budget`), wired through both live `complete()` and batch (sleep cycle) Messages calls.
- `adaptive` mode is for Opus 4.6+/Sonnet 4.6+ — sends `thinking: {type: "adaptive"}` plus optional `effort` (`low|medium|high|xhigh|max`) and optional `display: "summarized"` for Opus 4.7+. Interleaved thinking is automatic.
- `budget` mode is for older Claude 4 models — sends `thinking: {type: "enabled", budget_tokens: N}`. Optional `interleaved: true` stacks the `interleaved-thinking-2025-05-14` beta header.
- Client self-protects: drops the thinking block + warns if `budget_tokens >= max_tokens` (except when interleaved, where the budget is a per-turn total). Logs a warning at startup if the configured mode obviously mismatches the model (e.g. `budget` on Opus 4.7).
- Pydantic `model_validator` rejects nonsensical combos (`effort` on non-adaptive, `interleaved` on non-budget, etc.) at YAML load.
- Bumps bash tool default timeout from 30s → 50s — 30s was too shallow for common command paths.

Version bump: 0.8.2 → 0.9.0 (feature addition).

## Test plan

- [x] Unit tests pass (488 passed, 6 skipped — same 6 always skipped)
- [x] New tests in `tests/unit/test_config.py::TestThinkingConfig` cover defaults, valid combos, validator rejections
- [x] New tests in `tests/unit/test_llm.py::TestThinkingHelper` + `TestAnthropicClientThinkingIntegration` + `TestThinkingFactory` cover kwargs injection, beta header injection, budget>=max_tokens drop, factory threading, mock recording
- [ ] Tag `v0.9.0` after merge → triggers PyPI publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)