### PR TITLE
fix: don't false-warn 'adaptive on sonnet-4-6' (0.9.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.9.0"
+version = "0.9.1"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -71,9 +71,14 @@ def _build_thinking_kwargs(
 # matching is loose on purpose — Anthropic ships new models faster than
 # we can hardcode them, so we only flag the loudest known incompatibilities.
 _ADAPTIVE_ONLY_MODELS = ("claude-opus-4-7", "claude-opus-4-8", "claude-mythos")
+# Models that DO NOT support adaptive thinking — must use legacy budget mode.
+# Spelled out per-version to avoid prefix collisions: e.g. "claude-sonnet-4-"
+# would startswith-match "claude-sonnet-4-6", which IS adaptive-capable.
 _LEGACY_BUDGET_MODELS = (
     "claude-sonnet-3-7",
-    "claude-sonnet-4-",  # 4.0 / 4.1 / 4.5 (4.6+ accept budget but deprecated)
+    "claude-sonnet-4-0",
+    "claude-sonnet-4-1",
+    "claude-sonnet-4-5",
     "claude-opus-4-0",
     "claude-opus-4-1",
     "claude-opus-4-5",

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -373,6 +373,50 @@ class TestAnthropicClientThinkingIntegration:
         assert oc["effort"] == "high"
 
 
+class TestThinkingModelMismatchWarning:
+    """The startup warning must not false-positive on adaptive-capable models.
+
+    Regression for the 0.9.0 release where `claude-sonnet-4-` startswith-matched
+    `claude-sonnet-4-6` (which IS adaptive-capable) and warned spuriously.
+    """
+
+    def test_adaptive_on_sonnet_4_6_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agentlings.core.llm import _warn_if_mode_mismatches_model
+
+        with caplog.at_level("WARNING"):
+            _warn_if_mode_mismatches_model("adaptive", "claude-sonnet-4-6")
+        assert not any("does not support adaptive" in r.message for r in caplog.records)
+
+    def test_adaptive_on_sonnet_4_5_does_warn(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agentlings.core.llm import _warn_if_mode_mismatches_model
+
+        with caplog.at_level("WARNING"):
+            _warn_if_mode_mismatches_model("adaptive", "claude-sonnet-4-5")
+        assert any("does not support adaptive" in r.message for r in caplog.records)
+
+    def test_budget_on_opus_4_7_does_warn(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agentlings.core.llm import _warn_if_mode_mismatches_model
+
+        with caplog.at_level("WARNING"):
+            _warn_if_mode_mismatches_model("budget", "claude-opus-4-7")
+        assert any("rejects" in r.message for r in caplog.records)
+
+    def test_adaptive_on_opus_4_6_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from agentlings.core.llm import _warn_if_mode_mismatches_model
+
+        with caplog.at_level("WARNING"):
+            _warn_if_mode_mismatches_model("adaptive", "claude-opus-4-6")
+        assert not any("does not support adaptive" in r.message for r in caplog.records)
+
+
 class TestThinkingFactory:
     """The factory threads thinking through to whichever client it builds."""
 


### PR DESCRIPTION
## Summary

Patches the model/mode mismatch heuristic added in 0.9.0. The legacy-budget prefix list used `"claude-sonnet-4-"` which startswith-matches `claude-sonnet-4-6` — adaptive-capable — and emitted a spurious warning on every startup.

Switches to explicit per-version prefixes (`4-0`, `4-1`, `4-5`) so 4.6+ is correctly recognized as adaptive-capable.

## Test plan

- [x] Unit tests pass — new regression tests in `TestThinkingModelMismatchWarning` cover sonnet-4-6, sonnet-4-5, opus-4-6, opus-4-7
- [ ] Tag `v0.9.1` after merge → triggers PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)