### PR TITLE
feat: cap oversized tool results before they 413 the turn (0.10.0)

### DIFF
--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -20,6 +20,14 @@ system_prompt: |
 
   Be concise. Use code blocks for command output.
 
+# bash_timeout: 50            # default per-command bash timeout (seconds)
+# max_tool_result_chars: 32000  # cap a single tool result before it's truncated
+#                               # (with a marker) on its way back to the model.
+#                               # Stops a runaway tool (e.g. recursive grep over
+#                               # large files) from blowing the request body past
+#                               # the API size limit and failing the turn with a
+#                               # 413. Set 0 to disable truncation.
+
 memory:
   token_budget: 2000
   # injection_prompt: null  # override the memory injection template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.9.1"
+version = "0.10.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -185,6 +185,13 @@ class AgentDefinition(BaseModel):
         skills: Skills to advertise in the Agent Card.
         system_prompt: The system prompt sent to the LLM.
         bash_timeout: Default timeout in seconds for bash tool commands.
+        max_tool_result_chars: Maximum character length of a single tool result
+            before it is truncated (with a marker telling the model it was cut)
+            on its way back to the LLM. Guards against a runaway tool (e.g. a
+            recursive grep sweeping up minified assets) producing a multi-MB
+            result that blows the request body past the API's hard size limit
+            and fails the turn with a 413. Defaults to 32000; set ``0`` to
+            disable truncation.
         data_dir_awareness: When ``True`` (default), append a system-prompt
             block telling the agent where its data directory lives and how
             to read journals and conversation logs. Set to ``False`` for
@@ -205,6 +212,9 @@ class AgentDefinition(BaseModel):
     skills: list[SkillConfig] = Field(default_factory=list)
     system_prompt: str | None = None
     bash_timeout: int = Field(ge=1, default=50)
+    # Keep the default in sync with completion.DEFAULT_MAX_TOOL_RESULT_CHARS
+    # (literal here to avoid a config<->core import cycle). 0 disables truncation.
+    max_tool_result_chars: int = Field(ge=0, default=32_000)
     data_dir_awareness: bool = True
     send_name_header: bool = True
     memory: MemoryConfig | None = None

--- a/src/agentlings/core/completion.py
+++ b/src/agentlings/core/completion.py
@@ -15,6 +15,36 @@ from agentlings.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
+# Default cap on a single tool result's character length before it is truncated
+# on its way back to the model. A single runaway command (e.g. ``grep -r`` over
+# ``$HOME`` sweeping up minified assets) can otherwise produce a multi-MB result
+# that pushes the whole request body past the API's hard size limit, failing the
+# turn with a 413 instead of letting the model recover. Overridable per-agent via
+# ``AgentDefinition.max_tool_result_chars``; ``<= 0`` disables truncation.
+DEFAULT_MAX_TOOL_RESULT_CHARS = 32_000
+
+
+def _truncate_tool_output(output: str, limit: int) -> str:
+    """Cap an oversized tool result and tell the model it was truncated.
+
+    Keeps the first ``limit`` characters and appends a marker stating the
+    original size and how much was dropped, so the model knows the output is
+    incomplete and can re-run with a narrower command rather than silently
+    losing data. ``limit <= 0`` disables truncation and returns ``output``
+    unchanged.
+    """
+    if limit <= 0 or len(output) <= limit:
+        return output
+    dropped = len(output) - limit
+    notice = (
+        f"\n\n[agentling: tool result truncated — it was {len(output):,} chars, "
+        f"over the {limit:,}-char limit, so {dropped:,} chars were dropped. "
+        f"The text above is the first {limit:,} chars. Re-run with a more "
+        f"targeted command (narrower path, a grep filter, head -c, etc.) to see "
+        f"the rest.]"
+    )
+    return output[:limit] + notice
+
 
 class CancellationRequested(Exception):
     """Raised inside ``run_completion`` when a cancel callback returns ``True``.
@@ -98,6 +128,7 @@ async def run_completion(
     should_cancel: Callable[[], bool] | None = None,
     context_id: str | None = None,
     task_id: str | None = None,
+    max_tool_result_chars: int = DEFAULT_MAX_TOOL_RESULT_CHARS,
 ) -> CompletionResult:
     """Run the LLM in a loop, executing tool calls until a terminal text response.
 
@@ -122,6 +153,10 @@ async def run_completion(
             ``llm.complete`` call so each request carries the session header.
         task_id: The task execution this cycle belongs to. Forwarded to every
             ``llm.complete`` call so each request carries the task header.
+        max_tool_result_chars: Maximum character length of a single tool
+            result before it is truncated (with a marker) on its way back to
+            the model. Guards against a runaway tool blowing the request body
+            past the API's hard size limit. ``<= 0`` disables truncation.
 
     Returns:
         The final response content and all intermediate responses.
@@ -252,7 +287,7 @@ async def run_completion(
                     return {
                         "type": "tool_result",
                         "tool_use_id": block["id"],
-                        "content": result.output,
+                        "content": _truncate_tool_output(result.output, max_tool_result_chars),
                         "is_error": result.is_error,
                     }
                 except asyncio.CancelledError:

--- a/src/agentlings/core/task.py
+++ b/src/agentlings/core/task.py
@@ -527,6 +527,7 @@ class TaskWorker:
             should_cancel=lambda: record.cancel_flag,
             context_id=record.context_id,
             task_id=record.task_id,
+            max_tool_result_chars=self._config.definition.max_tool_result_chars,
         )
         # Stash so ``run`` can stamp the cycle's token totals onto the
         # worker span before exiting.

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 import pytest
 
-from agentlings.core.completion import run_completion
+from agentlings.core.completion import _truncate_tool_output, run_completion
 from agentlings.core.llm import LLMResponse, MockLLMClient
 from agentlings.tools.registry import ToolRegistry, ToolResult
 
@@ -405,3 +405,73 @@ class TestToolResultMessageContract:
         sent_ids = [b["id"] for b in assistant_msg["content"] if b["type"] == "tool_use"]
         recv_ids = [r["tool_use_id"] for r in tool_result_msg["content"]]
         assert sent_ids == recv_ids
+
+
+# ---------------------------------------------------------------------------
+# Tool result truncation — guard against oversized results (413 prevention)
+# ---------------------------------------------------------------------------
+
+class TestTruncateToolOutputHelper:
+    """Unit-level behaviour of the ``_truncate_tool_output`` helper."""
+
+    def test_under_limit_passes_through_unchanged(self) -> None:
+        out = "x" * 100
+        assert _truncate_tool_output(out, 32_000) == out
+
+    def test_exactly_at_limit_passes_through_unchanged(self) -> None:
+        out = "x" * 50
+        assert _truncate_tool_output(out, 50) == out
+
+    def test_over_limit_is_truncated_with_notice(self) -> None:
+        out = "x" * 1000
+        result = _truncate_tool_output(out, 100)
+        # First `limit` chars are preserved verbatim...
+        assert result.startswith("x" * 100)
+        # ...the original payload is not sent in full...
+        assert "x" * 1000 not in result
+        # ...and the model is told it was cut and by how much.
+        assert "truncated" in result
+        assert "900" in result  # dropped char count
+
+    def test_limit_zero_disables_truncation(self) -> None:
+        out = "x" * 1_000_000
+        assert _truncate_tool_output(out, 0) == out
+
+    def test_negative_limit_disables_truncation(self) -> None:
+        out = "x" * 1_000_000
+        assert _truncate_tool_output(out, -1) == out
+
+
+class TestRunCompletionTruncatesResults:
+    """The completion loop must cap oversized tool results before they reach the LLM."""
+
+    async def test_oversized_result_truncated_in_message(self) -> None:
+        huge = "A" * 200_000
+
+        async def _huge_tool(name: str, input_dict: dict[str, Any]) -> ToolResult:
+            return ToolResult(output=huge, is_error=False)
+
+        llm = _OneShotToolLLM(_tool_calls("big"))
+        messages = [{"role": "user", "content": [{"type": "text", "text": "go"}]}]
+        await run_completion(
+            llm, [], messages, _stub_registry(_huge_tool), max_tool_result_chars=1000
+        )
+
+        content = messages[2]["content"][0]["content"]
+        # Body capped to the limit, plus a (small) truncation notice.
+        assert content.startswith("A" * 1000)
+        assert len(content) < 2000
+        assert "truncated" in content
+
+    async def test_small_result_not_truncated(self) -> None:
+        async def _small_tool(name: str, input_dict: dict[str, Any]) -> ToolResult:
+            return ToolResult(output="just fine", is_error=False)
+
+        llm = _OneShotToolLLM(_tool_calls("small"))
+        messages = [{"role": "user", "content": [{"type": "text", "text": "go"}]}]
+        await run_completion(
+            llm, [], messages, _stub_registry(_small_tool), max_tool_result_chars=1000
+        )
+
+        assert messages[2]["content"][0]["content"] == "just fine"
+        assert "truncated" not in messages[2]["content"][0]["content"]


### PR DESCRIPTION
## Problem

A single runaway tool call can produce a multi-MB result that gets appended to the conversation verbatim and sent on the next turn — pushing the request body past the API's hard size limit. The turn dies with `RequestTooLargeError` (413) and the whole task fails, with no chance for the model to recover.

Seen in the wild on the office k3s-agentling: a `grep -r "...token..." /home/localuser/` swept up an AdBlock extension's minified `.js.map` + filter list (single physical lines megabytes long; `head -5` caps line *count*, not bytes), yielding a **16,962,062-char** tool result → 413 → `task_fail`.

```
POST .../v1/messages → HTTP 413 Request Entity Too Large
anthropic._exceptions.RequestTooLargeError: Error code: 413 - {'error': 'body too large'}
```

## Fix

Cap each tool result at a configurable character limit before it goes back to the model. Over the limit → keep the first N chars and append a marker stating the original size and how much was dropped, so the model knows the output is incomplete and can re-run with a narrower command rather than silently losing data.

```
[agentling: tool result truncated — it was 16,962,062 chars, over the 32,000-char
limit, so 16,930,062 chars were dropped. The text above is the first 32,000 chars.
Re-run with a more targeted command (narrower path, a grep filter, head -c, etc.)
to see the rest.]
```

## Changes

- **completion**: `_truncate_tool_output` helper + `max_tool_result_chars` param on `run_completion` (default `32000`; `<= 0` disables). Applied at the single point where `tool_result` blocks are built.
- **config**: `AgentDefinition.max_tool_result_chars` — set it in `agent.yaml` alongside `bash_timeout`. `0` disables truncation.
- **task**: thread the configured value into the completion cycle.
- **tests**: helper-level + end-to-end coverage (truncation, exact-limit pass-through, small results untouched, `0`/negative disable).
- **docs**: documented in `agent.example.yaml`.
- **version**: `0.9.1` → `0.10.0`.

## Testing

`pytest tests/unit/` — **500 passed, 5 skipped** (run from a clean cwd; the app dir's live `.env`/`agent.yaml` otherwise pollute the default-config assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)