### PR TITLE
feat: validate oauth bearer tokens on the http surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ All via environment variables (loaded from `.env` via python-dotenv):
 - `AGENT_SYSTEM_PROMPT_FILE` — optional path to override default system prompt
 - `AGENT_LOG_LEVEL` (default `INFO`)
 - `AGENT_TASK_AWAIT_SECONDS` (default `60`) — HTTP handler await timeout before yielding a task handle to the caller
+- `AGENT_OAUTH_ISSUER` / `AGENT_OAUTH_AUDIENCE` / `AGENT_OAUTH_JWKS_URI` (optional) — enable OAuth/OIDC bearer-token validation. Setting the issuer turns it on; the agentling acts as a resource server validating JWT signature + `iss`/`aud`/`exp` against the issuer's JWKS (derived from OIDC discovery when `jwks_uri` is unset). The API key and a bearer token are both accepted. Also configurable via an `oauth:` block in the agent YAML. Covers both `/mcp` (RFC 9728 Protected Resource Metadata + `WWW-Authenticate`) and `/a2a` (Agent Card `openIdConnect` scheme).
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,32 @@ Secrets and runtime settings stay in env vars or, more commonly, the `.env` file
 | `AGENT_OTEL_PROTOCOL` | `http` | Collector protocol (`http` or `grpc`) |
 | `AGENT_OTEL_INSECURE` | `true` | Disable TLS for collector connection |
 | `AGENT_OTEL_HEADERS` | — | Comma-separated `key=value` pairs for collector auth |
+| `AGENT_OAUTH_ISSUER` | — | OAuth/OIDC issuer URL; setting it enables bearer-token validation |
+| `AGENT_OAUTH_AUDIENCE` | — | Resource identifier validated against the token's `aud` claim |
+| `AGENT_OAUTH_JWKS_URI` | — | JWKS endpoint; derived from the issuer's OIDC discovery doc when unset |
+
+## OAuth
+
+Beyond the shared `AGENT_API_KEY`, an agentling can accept **OAuth 2.0 bearer tokens** issued by an external identity provider (Keycloak, Auth0, Entra, …). It acts purely as a *resource server*: it validates a token's signature against the issuer's published JWKS and checks `iss`/`aud`/`exp`. It never issues tokens, inspects user identity, or enforces scopes — any validly-signed, correctly-audienced, unexpired token from the trusted issuer is accepted.
+
+Enable it with an `oauth` block in `agent.yaml` (or the `AGENT_OAUTH_*` env vars above):
+
+```yaml
+oauth:
+  enabled: true
+  issuer: https://auth.example.com/realms/Agents
+  audience: my-agentling-api          # must match the token's aud claim
+  jwks_uri: null                      # optional; derived from OIDC discovery when omitted
+```
+
+Both protocol surfaces are covered by a single auth layer — the API key and a bearer token are *both* accepted (either credential passes), so existing API-key clients keep working while OAuth clients use tokens. Each protocol advertises the requirement in its own dialect:
+
+- **MCP** serves RFC 9728 Protected Resource Metadata at `/.well-known/oauth-protected-resource` (and the path-suffixed `/mcp` variant) and returns `401` with a `WWW-Authenticate` challenge pointing at it.
+- **A2A** declares an `openIdConnect` security scheme in the Agent Card, pointing clients at the issuer's `/.well-known/openid-configuration`.
+
+Both documents are generated from the single `oauth` block, so they can never drift from what the server actually validates. The provider hosts all authorization-server metadata; the agentling only names the issuer.
+
+> **Audience binding is the security boundary.** Configure your IdP to issue tokens whose `aud` contains the value in `audience` (e.g. a Keycloak *Audience* protocol mapper or client scope). A token minted for a different resource will be rejected — which is exactly what stops a token issued for one agentling being replayed against another.
 
 ## Memory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.10.0"
+version = "0.11.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }
@@ -32,6 +32,8 @@ dependencies = [
     "mcp>=1.10.0",
     "python-dotenv>=1.1",
     "pyyaml>=6.0",
+    "pyjwt[crypto]>=2.10",
+    "httpx>=0.28",
     "opentelemetry-api>=1.20",
     "opentelemetry-sdk>=1.20",
     "opentelemetry-exporter-otlp>=1.20",

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -159,6 +159,38 @@ class TelemetryConfig(BaseModel):
     headers: dict[str, str] = Field(default_factory=dict)
 
 
+class OAuthConfig(BaseModel):
+    """OAuth/OIDC bearer-token validation for the HTTP surface.
+
+    The agentling acts purely as an OAuth 2.0 Resource Server: it validates
+    the ``Authorization: Bearer`` JWT's signature against the issuer's
+    published JWKS and checks ``iss``/``aud``/``exp``. It never issues tokens,
+    inspects user identity, or enforces scopes — a validly-signed,
+    correctly-audienced, unexpired token from the trusted issuer is accepted.
+
+    Attributes:
+        enabled: Whether bearer-token validation is active. When ``False`` the
+            HTTP surface is protected by the API key alone.
+        issuer: The token issuer URL, matched against the ``iss`` claim and
+            advertised to clients (e.g. ``https://auth.example.com/realms/x``).
+        audience: The resource identifier this server validates against the
+            token's ``aud`` claim. A token whose ``aud`` (string or array)
+            contains this value is accepted.
+        jwks_uri: The issuer's JWKS endpoint. When ``None`` it is resolved at
+            first use from the issuer's OIDC discovery document
+            (``{issuer}/.well-known/openid-configuration``).
+        algorithms: Permitted JWS signing algorithms.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = False
+    issuer: str = ""
+    audience: str = ""
+    jwks_uri: str | None = None
+    algorithms: list[str] = Field(default_factory=lambda: ["RS256"])
+
+
 class SkillConfig(BaseModel):
     """A skill advertised in the Agent Card.
 
@@ -221,6 +253,7 @@ class AgentDefinition(BaseModel):
     sleep: SleepConfig | None = None
     telemetry: TelemetryConfig | None = None
     thinking: ThinkingConfig | None = None
+    oauth: OAuthConfig | None = None
 
 
 class AgentConfig(BaseSettings):
@@ -256,6 +289,9 @@ class AgentConfig(BaseSettings):
     agent_otel_headers: str = ""
     agent_task_await_seconds: int = 60
     agent_tools_dir: Path | None = None
+    agent_oauth_issuer: str | None = None
+    agent_oauth_audience: str | None = None
+    agent_oauth_jwks_uri: str | None = None
 
     _definition: AgentDefinition = AgentDefinition()
 
@@ -315,6 +351,31 @@ class AgentConfig(BaseSettings):
     def sleep_config(self) -> SleepConfig | None:
         """Sleep cycle configuration from the YAML definition."""
         return self._definition.sleep
+
+    @property
+    def oauth_config(self) -> OAuthConfig | None:
+        """OAuth configuration, with env vars overriding YAML values.
+
+        Returns ``None`` unless OAuth is enabled, either by an ``oauth`` block
+        in the YAML definition with ``enabled: true`` or by setting
+        ``AGENT_OAUTH_ISSUER`` (which implies enablement).
+        """
+        base = self._definition.oauth
+        if self.agent_oauth_issuer:
+            if base is None:
+                base = OAuthConfig(enabled=True)
+            updates: dict[str, Any] = {
+                "enabled": True,
+                "issuer": self.agent_oauth_issuer,
+            }
+            if self.agent_oauth_audience:
+                updates["audience"] = self.agent_oauth_audience
+            if self.agent_oauth_jwks_uri:
+                updates["jwks_uri"] = self.agent_oauth_jwks_uri
+            base = base.model_copy(update=updates)
+        if base is None or not base.enabled:
+            return None
+        return base
 
     @property
     def telemetry_config(self) -> TelemetryConfig | None:

--- a/src/agentlings/protocol/agent_card.py
+++ b/src/agentlings/protocol/agent_card.py
@@ -8,6 +8,7 @@ from a2a.types import (
     AgentInterface,
     AgentSkill,
     APIKeySecurityScheme,
+    OpenIdConnectSecurityScheme,
     SecurityRequirement,
     SecurityScheme,
     StringList,
@@ -54,6 +55,33 @@ def generate_agent_card(config: AgentConfig) -> AgentCard:
             )
         ]
 
+    security_schemes: dict[str, SecurityScheme] = {
+        "apiKey": SecurityScheme(
+            api_key_security_scheme=APIKeySecurityScheme(
+                location="header",
+                name="X-API-Key",
+            )
+        )
+    }
+    # Two requirements in the list mean "apiKey OR oidc", mirroring the
+    # either-credential-works behaviour of the auth middleware.
+    security_requirements = [
+        SecurityRequirement(schemes={"apiKey": StringList(list=[])})
+    ]
+
+    oauth = config.oauth_config
+    if oauth is not None:
+        security_schemes["oidc"] = SecurityScheme(
+            open_id_connect_security_scheme=OpenIdConnectSecurityScheme(
+                open_id_connect_url=(
+                    oauth.issuer.rstrip("/") + "/.well-known/openid-configuration"
+                ),
+            )
+        )
+        security_requirements.append(
+            SecurityRequirement(schemes={"oidc": StringList(list=[])})
+        )
+
     return AgentCard(
         name=config.agent_name,
         description=config.agent_description,
@@ -69,15 +97,6 @@ def generate_agent_card(config: AgentConfig) -> AgentCard:
         capabilities=AgentCapabilities(streaming=False, push_notifications=False),
         default_input_modes=["text"],
         default_output_modes=["text"],
-        security_schemes={
-            "apiKey": SecurityScheme(
-                api_key_security_scheme=APIKeySecurityScheme(
-                    location="header",
-                    name="X-API-Key",
-                )
-            )
-        },
-        security_requirements=[
-            SecurityRequirement(schemes={"apiKey": StringList(list=[])})
-        ],
+        security_schemes=security_schemes,
+        security_requirements=security_requirements,
     )

--- a/src/agentlings/server.py
+++ b/src/agentlings/server.py
@@ -8,7 +8,10 @@ import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
+import httpx
+import jwt
 import uvicorn
+from jwt import PyJWKClient
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.routes.agent_card_routes import create_agent_card_routes
 from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
@@ -20,7 +23,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
-from agentlings.config import AgentConfig
+from agentlings.config import AgentConfig, OAuthConfig
 from agentlings.core.llm import create_llm_client
 from agentlings.core.loop import MessageLoop
 from agentlings.core.memory_store import MemoryFileStore
@@ -40,37 +43,107 @@ from agentlings.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
+_PROTECTED_RESOURCE_PATHS = {
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-protected-resource/mcp",
+}
+
 _PUBLIC_PATHS = {
     "/.well-known/agent.json",
     "/.well-known/agent-card.json",
+    *_PROTECTED_RESOURCE_PATHS,
 }
 
 
-class APIKeyMiddleware(BaseHTTPMiddleware):
-    """Middleware that enforces ``X-API-Key`` header authentication on non-public paths."""
+def _resolve_jwks_uri(oauth: OAuthConfig) -> str:
+    """Return the JWKS endpoint, deriving it from OIDC discovery if unset.
 
-    def __init__(self, app: Any, api_key: str) -> None:
+    A configured ``jwks_uri`` is used verbatim. Otherwise the issuer's OIDC
+    discovery document is fetched and its ``jwks_uri`` field returned — the one
+    mechanism that works uniformly across IdPs (Keycloak, Auth0, Entra, …),
+    which all publish different JWKS paths.
+    """
+    if oauth.jwks_uri:
+        return oauth.jwks_uri
+    discovery_url = oauth.issuer.rstrip("/") + "/.well-known/openid-configuration"
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(discovery_url)
+        response.raise_for_status()
+        return response.json()["jwks_uri"]
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Authenticate non-public requests via an ``X-API-Key`` or an OAuth Bearer JWT.
+
+    Either credential is accepted. The API key is a single shared secret. The
+    Bearer path validates the JWT's signature against the issuer's published
+    JWKS and checks ``iss``/``aud``/``exp`` — no scope or per-user
+    authorization. When OAuth is disabled this behaves exactly like a plain
+    API-key gate.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        api_key: str,
+        oauth: OAuthConfig | None = None,
+        resource_metadata_url: str | None = None,
+    ) -> None:
         super().__init__(app)
         self._api_key = api_key
+        self._oauth = oauth
+        self._resource_metadata_url = resource_metadata_url
+        # JWKS client construction (and any OIDC-discovery fetch it needs)
+        # is deferred to the first bearer request so app startup never blocks
+        # on the IdP being reachable.
+        self._jwks_client: PyJWKClient | None = None
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
-        """Check the API key header and reject unauthorized requests.
-
-        Args:
-            request: The incoming HTTP request.
-            call_next: Callable to pass the request to the next middleware or route.
-
-        Returns:
-            The downstream response, or a 401 JSON response if unauthorized.
-        """
         if request.url.path in _PUBLIC_PATHS:
             return await call_next(request)
 
-        key = request.headers.get("x-api-key", "")
-        if key != self._api_key:
-            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+        if self._api_key and request.headers.get("x-api-key", "") == self._api_key:
+            return await call_next(request)
 
-        return await call_next(request)
+        if self._oauth is not None and self._valid_bearer(request):
+            return await call_next(request)
+
+        return self._unauthorized()
+
+    def _valid_bearer(self, request: Request) -> bool:
+        assert self._oauth is not None
+        header = request.headers.get("authorization", "")
+        if not header.lower().startswith("bearer "):
+            return False
+        token = header[7:].strip()
+        try:
+            signing_key = self._jwks().get_signing_key_from_jwt(token)
+            jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=self._oauth.algorithms,
+                audience=self._oauth.audience,
+                issuer=self._oauth.issuer,
+            )
+            return True
+        except Exception:  # noqa: BLE001 — any verification failure is an auth failure
+            logger.debug("bearer token rejected", exc_info=True)
+            return False
+
+    def _jwks(self) -> PyJWKClient:
+        assert self._oauth is not None
+        if self._jwks_client is None:
+            self._jwks_client = PyJWKClient(_resolve_jwks_uri(self._oauth))
+        return self._jwks_client
+
+    def _unauthorized(self) -> Response:
+        headers: dict[str, str] = {}
+        if self._oauth is not None and self._resource_metadata_url:
+            headers["WWW-Authenticate"] = (
+                f'Bearer resource_metadata="{self._resource_metadata_url}"'
+            )
+        return JSONResponse({"error": "Unauthorized"}, status_code=401, headers=headers)
 
 
 class TelemetryMiddleware(BaseHTTPMiddleware):
@@ -131,6 +204,26 @@ class TelemetryMiddleware(BaseHTTPMiddleware):
                     otel_context.detach(token)
                 except Exception:  # noqa: BLE001
                     pass
+
+
+def _external_base_url(config: AgentConfig) -> str:
+    """The canonical externally-reachable base URL for this agentling."""
+    if config.agent_external_url:
+        return config.agent_external_url.rstrip("/")
+    return f"http://{config.agent_host}:{config.agent_port}"
+
+
+def _protected_resource_metadata(config: AgentConfig, oauth: OAuthConfig) -> dict[str, Any]:
+    """Build the RFC 9728 Protected Resource Metadata document.
+
+    Generated from config so it can never drift from what ``AuthMiddleware``
+    actually validates against.
+    """
+    return {
+        "resource": _external_base_url(config) + "/mcp",
+        "authorization_servers": [oauth.issuer],
+        "bearer_methods_supported": ["header"],
+    }
 
 
 def _create_app(config: AgentConfig | None = None) -> Starlette:
@@ -285,6 +378,9 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         agent_card=agent_card, card_url="/.well-known/agent.json"
     )
 
+    oauth = config.oauth_config
+    resource_metadata_url: str | None = None
+
     routes = [
         Route("/mcp", mcp_endpoint, methods=["GET", "POST", "DELETE"]),
         *jsonrpc_routes,
@@ -292,10 +388,36 @@ def _create_app(config: AgentConfig | None = None) -> Starlette:
         *legacy_card_routes,
     ]
 
+    if oauth is not None:
+        resource_metadata_url = (
+            _external_base_url(config) + "/.well-known/oauth-protected-resource"
+        )
+        metadata = _protected_resource_metadata(config, oauth)
+
+        async def protected_resource_metadata(request: Request) -> Response:
+            return JSONResponse(metadata)
+
+        # Serve at both the bare path and the RFC 9728 path-suffixed variant
+        # (for resource ``/mcp``) so strict and lenient clients both resolve it.
+        routes.extend(
+            Route(path, protected_resource_metadata, methods=["GET"])
+            for path in sorted(_PROTECTED_RESOURCE_PATHS)
+        )
+        logger.info(
+            "oauth bearer-token validation enabled (issuer=%s, audience=%s)",
+            oauth.issuer,
+            oauth.audience,
+        )
+
     middleware = [
         # Telemetry runs outermost so it observes auth failures too.
         Middleware(TelemetryMiddleware),
-        Middleware(APIKeyMiddleware, api_key=config.agent_api_key),
+        Middleware(
+            AuthMiddleware,
+            api_key=config.agent_api_key,
+            oauth=oauth,
+            resource_metadata_url=resource_metadata_url,
+        ),
     ]
 
     app = Starlette(

--- a/tests/unit/test_agent_card.py
+++ b/tests/unit/test_agent_card.py
@@ -28,10 +28,41 @@ def test_generated_card_security(test_config: AgentConfig) -> None:
     card = generate_agent_card(test_config)
     assert card.security_schemes is not None
     assert "apiKey" in card.security_schemes
+    assert "oidc" not in card.security_schemes
     # security_requirements is a repeated SecurityRequirement; we advertise
     # a single requirement keying on ``apiKey``.
     assert len(card.security_requirements) == 1
     assert "apiKey" in card.security_requirements[0].schemes
+
+
+def test_card_advertises_oidc_when_oauth_enabled(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "agent.yaml"
+    yaml_file.write_text(
+        "name: secured\n"
+        "description: Secured agent\n"
+        "oauth:\n"
+        "  enabled: true\n"
+        "  issuer: https://auth.donkeywork.dev/realms/Agents\n"
+        "  audience: donkeywork-agents-api\n"
+    )
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        agent_config=str(yaml_file),
+        _env_file=None,
+    )
+    card = generate_agent_card(config)
+    assert "apiKey" in card.security_schemes
+    assert "oidc" in card.security_schemes
+    assert (
+        card.security_schemes["oidc"].open_id_connect_security_scheme.open_id_connect_url
+        == "https://auth.donkeywork.dev/realms/Agents/.well-known/openid-configuration"
+    )
+    # apiKey OR oidc — two independent requirements.
+    requirement_keys = [set(r.schemes.keys()) for r in card.security_requirements]
+    assert {"apiKey"} in requirement_keys
+    assert {"oidc"} in requirement_keys
 
 
 def test_skills_from_yaml(test_config: AgentConfig) -> None:

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agentlings import server
+from agentlings.config import OAuthConfig
+from agentlings.server import AuthMiddleware
+
+ISSUER = "https://auth.example.com/realms/Agents"
+AUDIENCE = "donkeywork-agents-api"
+RESOURCE_METADATA_URL = "https://agent.example.com/.well-known/oauth-protected-resource"
+
+
+@pytest.fixture(scope="module")
+def keypair() -> tuple[Any, Any]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _mint(private_key: Any, **claims: Any) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": now,
+        "exp": now + datetime.timedelta(minutes=5),
+        **claims,
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+@pytest.fixture
+def app_factory(keypair: tuple[Any, Any], monkeypatch: pytest.MonkeyPatch):
+    """Build a Starlette app guarded by AuthMiddleware with a stubbed JWKS.
+
+    The fake JWKS client returns the test public key, so the real signature
+    verification path in ``jwt.decode`` runs without any network access.
+    """
+    _, public_key = keypair
+
+    class _FakeJWKClient:
+        def __init__(self, uri: str) -> None:
+            self._uri = uri
+
+        def get_signing_key_from_jwt(self, token: str) -> Any:
+            return SimpleNamespace(key=public_key)
+
+    monkeypatch.setattr(server, "PyJWKClient", _FakeJWKClient)
+
+    def _build(oauth: OAuthConfig | None) -> TestClient:
+        async def protected(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("ok")
+
+        async def public_doc(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("public")
+
+        routes = [
+            Route("/mcp", protected, methods=["GET", "POST"]),
+            Route(
+                "/.well-known/oauth-protected-resource",
+                public_doc,
+                methods=["GET"],
+            ),
+        ]
+        middleware = [
+            Middleware(
+                AuthMiddleware,
+                api_key="secret-key",
+                oauth=oauth,
+                resource_metadata_url=RESOURCE_METADATA_URL if oauth else None,
+            )
+        ]
+        app = Starlette(routes=routes, middleware=middleware)
+        return TestClient(app)
+
+    return _build
+
+
+@pytest.fixture
+def oauth() -> OAuthConfig:
+    return OAuthConfig(
+        enabled=True,
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        jwks_uri="https://auth.example.com/jwks",
+    )
+
+
+def test_valid_api_key_passes(app_factory, oauth: OAuthConfig) -> None:
+    client = app_factory(oauth)
+    resp = client.get("/mcp", headers={"X-API-Key": "secret-key"})
+    assert resp.status_code == 200
+
+
+def test_no_credentials_rejected_with_challenge(app_factory, oauth: OAuthConfig) -> None:
+    client = app_factory(oauth)
+    resp = client.get("/mcp")
+    assert resp.status_code == 401
+    assert RESOURCE_METADATA_URL in resp.headers.get("www-authenticate", "")
+
+
+def test_valid_bearer_passes(app_factory, oauth: OAuthConfig, keypair) -> None:
+    private_key, _ = keypair
+    client = app_factory(oauth)
+    token = _mint(private_key)
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_valid_bearer_with_array_audience_passes(
+    app_factory, oauth: OAuthConfig, keypair
+) -> None:
+    """Keycloak issues ``aud`` as an array; the configured audience must be
+    accepted when it is a member of that array (the live notes-api shape)."""
+    private_key, _ = keypair
+    client = app_factory(oauth)
+    token = _mint(private_key, aud=[AUDIENCE, "account"])
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_expired_token_rejected(app_factory, oauth: OAuthConfig, keypair) -> None:
+    private_key, _ = keypair
+    client = app_factory(oauth)
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+    token = _mint(private_key, exp=past, iat=past)
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_wrong_audience_rejected(app_factory, oauth: OAuthConfig, keypair) -> None:
+    private_key, _ = keypair
+    client = app_factory(oauth)
+    token = _mint(private_key, aud="some-other-resource")
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_wrong_issuer_rejected(app_factory, oauth: OAuthConfig, keypair) -> None:
+    private_key, _ = keypair
+    client = app_factory(oauth)
+    token = _mint(private_key, iss="https://evil.example.com/realms/Agents")
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_bad_signature_rejected(app_factory, oauth: OAuthConfig) -> None:
+    """A token signed by a different key fails verification against the JWKS."""
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    client = app_factory(oauth)
+    token = _mint(other_key)
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_malformed_authorization_header_rejected(
+    app_factory, oauth: OAuthConfig
+) -> None:
+    client = app_factory(oauth)
+    resp = client.get("/mcp", headers={"Authorization": "Basic abc123"})
+    assert resp.status_code == 401
+
+
+def test_public_path_bypasses_auth(app_factory, oauth: OAuthConfig) -> None:
+    client = app_factory(oauth)
+    resp = client.get("/.well-known/oauth-protected-resource")
+    assert resp.status_code == 200
+    assert resp.text == "public"
+
+
+def test_bearer_ignored_when_oauth_disabled(app_factory, keypair) -> None:
+    """With OAuth off, a bearer token is not honoured — only the API key is."""
+    private_key, _ = keypair
+    client = app_factory(None)
+    token = _mint(private_key)
+    resp = client.get("/mcp", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    resp = client.get("/mcp", headers={"X-API-Key": "secret-key"})
+    assert resp.status_code == 200
+
+
+def test_resolve_jwks_uri_uses_explicit_value() -> None:
+    oauth = OAuthConfig(
+        enabled=True, issuer=ISSUER, audience=AUDIENCE, jwks_uri="https://x/jwks"
+    )
+    assert server._resolve_jwks_uri(oauth) == "https://x/jwks"
+
+
+def test_resolve_jwks_uri_derives_from_oidc_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When jwks_uri is unset, it is read from the issuer's OIDC discovery doc."""
+    derived = ISSUER + "/protocol/openid-connect/certs"
+    captured: dict[str, str] = {}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, str]:
+            return {"jwks_uri": derived}
+
+    class _FakeClient:
+        def __init__(self, timeout: float) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeClient":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            pass
+
+        def get(self, url: str) -> _FakeResponse:
+            captured["url"] = url
+            return _FakeResponse()
+
+    monkeypatch.setattr(server.httpx, "Client", _FakeClient)
+    oauth = OAuthConfig(enabled=True, issuer=ISSUER, audience=AUDIENCE, jwks_uri=None)
+    assert server._resolve_jwks_uri(oauth) == derived
+    assert captured["url"] == ISSUER + "/.well-known/openid-configuration"
+
+
+def test_protected_resource_metadata_shape() -> None:
+    from agentlings.config import AgentConfig
+
+    config = AgentConfig(
+        anthropic_api_key="x",
+        agent_api_key="k",
+        agent_external_url="https://agent.example.com",
+        _env_file=None,
+    )
+    oauth = OAuthConfig(enabled=True, issuer=ISSUER, audience=AUDIENCE)
+    doc = server._protected_resource_metadata(config, oauth)
+    assert doc["resource"] == "https://agent.example.com/mcp"
+    assert doc["authorization_servers"] == [ISSUER]
+    assert doc["bearer_methods_supported"] == ["header"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,11 +8,104 @@ from agentlings.config import (
     AgentConfig,
     AgentDefinition,
     MemoryConfig,
+    OAuthConfig,
     SkillConfig,
     SleepConfig,
     TelemetryConfig,
     ThinkingConfig,
 )
+
+
+def _clear_oauth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "AGENT_OAUTH_ISSUER",
+        "AGENT_OAUTH_AUDIENCE",
+        "AGENT_OAUTH_JWKS_URI",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_oauth_disabled_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_oauth_env(monkeypatch)
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        _env_file=None,
+    )
+    assert config.oauth_config is None
+
+
+def test_oauth_from_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_oauth_env(monkeypatch)
+    yaml_file = tmp_path / "agent.yaml"
+    yaml_file.write_text(
+        "name: secured\n"
+        "description: Secured agent\n"
+        "oauth:\n"
+        "  enabled: true\n"
+        "  issuer: https://auth.donkeywork.dev/realms/Agents\n"
+        "  audience: donkeywork-agents-api\n"
+    )
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        agent_config=str(yaml_file),
+        _env_file=None,
+    )
+    oauth = config.oauth_config
+    assert oauth is not None
+    assert oauth.issuer == "https://auth.donkeywork.dev/realms/Agents"
+    assert oauth.audience == "donkeywork-agents-api"
+    assert oauth.jwks_uri is None
+    assert oauth.algorithms == ["RS256"]
+
+
+def test_oauth_yaml_disabled_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_oauth_env(monkeypatch)
+    yaml_file = tmp_path / "agent.yaml"
+    yaml_file.write_text(
+        "name: secured\n"
+        "oauth:\n"
+        "  enabled: false\n"
+        "  issuer: https://auth.donkeywork.dev/realms/Agents\n"
+    )
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        agent_config=str(yaml_file),
+        _env_file=None,
+    )
+    assert config.oauth_config is None
+
+
+def test_oauth_env_enables_and_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting the issuer via env enables OAuth and overrides YAML values."""
+    monkeypatch.setenv("AGENT_OAUTH_ISSUER", "https://env-issuer/realms/X")
+    monkeypatch.setenv("AGENT_OAUTH_AUDIENCE", "env-audience")
+    monkeypatch.setenv(
+        "AGENT_OAUTH_JWKS_URI", "https://env-issuer/realms/X/protocol/openid-connect/certs"
+    )
+    config = AgentConfig(
+        anthropic_api_key="sk-test",
+        agent_api_key="key",
+        agent_data_dir=tmp_path / "data",
+        _env_file=None,
+    )
+    oauth = config.oauth_config
+    assert oauth is not None
+    assert oauth.enabled is True
+    assert oauth.issuer == "https://env-issuer/realms/X"
+    assert oauth.audience == "env-audience"
+    assert oauth.jwks_uri.endswith("/protocol/openid-connect/certs")
 
 
 def test_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Agentlings could only authenticate clients with a single shared API key. This adds optional OAuth 2.0 / OIDC bearer-token validation so MCP and A2A clients can authenticate against an external IdP (Keycloak, Auth0, Entra) without any bespoke integration.

- `AuthMiddleware` accepts an `X-API-Key` **or** a bearer JWT — either passes, so existing API-key clients keep working through a migration.
- Resource-server only: verify the JWT signature against the issuer's JWKS and check `iss`/`aud`/`exp`. No scopes, no user inspection — a validly-signed, correctly-audienced, unexpired token from the trusted issuer is accepted.
- `jwks_uri` is derived from the issuer's OIDC discovery document when unset, since IdPs publish JWKS at different paths (a hardcoded suffix is wrong — Keycloak uses `/protocol/openid-connect/certs`).
- One middleware covers both surfaces. MCP advertises RFC 9728 Protected Resource Metadata at `/.well-known/oauth-protected-resource` (+ the `/mcp`-suffixed variant) and challenges with `WWW-Authenticate`; A2A advertises an `openIdConnect` scheme in the Agent Card. Both documents are generated from the single `oauth` config block so they cannot drift from what the middleware validates.
- JWKS construction and the discovery fetch are lazy (first bearer request) so startup never blocks on the IdP; the JWK set is cached for 5 minutes per PyJWKClient defaults.
- Configurable via an `oauth` block in `agent.yaml` or `AGENT_OAUTH_*` env vars. Adds `pyjwt[crypto]` + `httpx`. Version bumped to 0.11.0.