### PR TITLE
docs: document MCP icons config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Package structure under `src/agentlings/`:
   - `completion.py` — shared LLM completion cycle with per-turn callback + cancellation
 - `protocol/` — protocol adapters
   - `a2a.py` — `AgentlingExecutor` bridging A2A SDK to the task engine
-  - `mcp.py` — MCP server exposing a single task-aware tool
+  - `mcp.py` — MCP server exposing task-aware tools (spawn + `__get_task`), with optional server/tool icons
   - `agent_card.py` — Agent Card generation from config
 - `tools/` — pluggable tool system
   - `registry.py` — `ToolRegistry` with group-based registration
@@ -81,6 +81,7 @@ All via environment variables (loaded from `.env` via python-dotenv):
 - `AGENT_LOG_LEVEL` (default `INFO`)
 - `AGENT_TASK_AWAIT_SECONDS` (default `60`) — HTTP handler await timeout before yielding a task handle to the caller
 - `AGENT_OAUTH_ISSUER` / `AGENT_OAUTH_AUDIENCE` / `AGENT_OAUTH_JWKS_URI` (optional) — enable OAuth/OIDC bearer-token validation. Setting the issuer turns it on; the agentling acts as a resource server validating JWT signature + `iss`/`aud`/`exp` against the issuer's JWKS (derived from OIDC discovery when `jwks_uri` is unset). The API key and a bearer token are both accepted. Also configurable via an `oauth:` block in the agent YAML. Covers both `/mcp` (RFC 9728 Protected Resource Metadata + `WWW-Authenticate`) and `/a2a` (Agent Card `openIdConnect` scheme).
+- `icons` (agent YAML only) — optional `icons:` block advertising PNG icons on the MCP surface. Keys `server` / `spawn` / `task` are base-URL stems; the framework appends `-<size>.png` for sizes 16/32/64/128/256/512 (`ICON_SIZES`) and emits one MCP `Icon` per size on `serverInfo.icons` and the matching tool. See README "Icons".
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,21 @@ Both documents are generated from the single `oauth` block, so they can never dr
 
 > **Audience binding is the security boundary.** Configure your IdP to issue tokens whose `aud` contains the value in `audience` (e.g. a Keycloak *Audience* protocol mapper or client scope). A token minted for a different resource will be rejected — which is exactly what stops a token issued for one agentling being replayed against another.
 
+## Icons
+
+An agentling can advertise PNG **icons** on its MCP surface so clients can show a recognizable image for the server and its tools. Icons ride on the standard MCP `Icon` type — the server's on `serverInfo.icons`, and one set per tool (the spawn tool named after the agent, and its `__get_task` companion).
+
+Configure with an `icons` block in `agent.yaml`:
+
+```yaml
+icons:
+  server: https://cdn.example.com/icons/agentling   # MCP serverInfo icon
+  spawn:  https://cdn.example.com/icons/play         # the main (spawn) tool
+  task:   https://cdn.example.com/icons/task         # the __get_task tool
+```
+
+Each value is a **base URL stem**: the framework appends `-<size>.png` for every size in `ICON_SIZES` — **16, 32, 64, 128, 256, 512** — and emits one `Icon` per resolution so clients pick the best fit for their display. So `server: …/agentling` advertises `agentling-16.png` through `agentling-512.png`; host those six PNGs at the corresponding URLs (any public store/CDN, served as `image/png`). Omit a key — or the whole block — to send no icons for that surface.
+
 ## Memory
 
 Agentlings can maintain persistent long-term memory — a curated set of key-value facts that survive across conversations. Memory transforms an agent from a tool that forgets into one that learns.

--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -72,3 +72,20 @@ telemetry:
   insecure: true                      # disable TLS for collector connection
   # headers:
   #   Authorization: "Bearer your-token"
+
+# oauth:
+#   # OAuth 2.0 bearer-token validation (resource server). Off unless `enabled`
+#   # is set or AGENT_OAUTH_ISSUER is present. The API key and a bearer token are
+#   # BOTH accepted, so existing API-key clients keep working. See README "OAuth".
+#   enabled: true
+#   issuer: https://auth.example.com/realms/Agents
+#   audience: my-agentling-api          # must match the token's aud claim
+#   jwks_uri: null                      # optional; derived from OIDC discovery when omitted
+
+# icons:
+#   # PNG icons advertised on the MCP surface (serverInfo + per-tool). Each value
+#   # is a base-URL stem; the framework appends -<size>.png for sizes
+#   # 16/32/64/128/256/512 and emits one Icon per size. See README "Icons".
+#   server: https://cdn.example.com/icons/agentling   # MCP server icon
+#   spawn:  https://cdn.example.com/icons/play         # main (spawn) tool
+#   task:   https://cdn.example.com/icons/task         # __get_task tool


### PR DESCRIPTION
Documents the `icons:` config added in 0.12.0 (the feature shipped without docs):

- **README.md** — new `## Icons` section (server/spawn/task base URLs, the `-<size>.png` convention over `ICON_SIZES` 16–512, how they map to `serverInfo.icons` + per-tool `icons`).
- **CLAUDE.md** — config bullet for the `icons:` block; corrected the `mcp.py` note (exposes two tools, not one).
- **agent.example.yaml** — commented `oauth:` and `icons:` example blocks (the file had neither).

Docs only — no code or behaviour change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)