### PR TITLE
fix: advertise a single MCP icon per surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ All via environment variables (loaded from `.env` via python-dotenv):
 - `AGENT_LOG_LEVEL` (default `INFO`)
 - `AGENT_TASK_AWAIT_SECONDS` (default `60`) — HTTP handler await timeout before yielding a task handle to the caller
 - `AGENT_OAUTH_ISSUER` / `AGENT_OAUTH_AUDIENCE` / `AGENT_OAUTH_JWKS_URI` (optional) — enable OAuth/OIDC bearer-token validation. Setting the issuer turns it on; the agentling acts as a resource server validating JWT signature + `iss`/`aud`/`exp` against the issuer's JWKS (derived from OIDC discovery when `jwks_uri` is unset). The API key and a bearer token are both accepted. Also configurable via an `oauth:` block in the agent YAML. Covers both `/mcp` (RFC 9728 Protected Resource Metadata + `WWW-Authenticate`) and `/a2a` (Agent Card `openIdConnect` scheme).
-- `icons` (agent YAML only) — optional `icons:` block advertising PNG icons on the MCP surface. Keys `server` / `spawn` / `task` are base-URL stems; the framework appends `-<size>.png` for sizes 16/32/64/128/256/512 (`ICON_SIZES`) and emits one MCP `Icon` per size on `serverInfo.icons` and the matching tool. See README "Icons".
+- `icons` (agent YAML only) — optional `icons:` block advertising icons on the MCP surface. Keys `server` / `spawn` / `task` are full icon URLs (HTTPS or `data:` URI); the framework emits a single MCP `Icon` per surface (`serverInfo.icons` and the matching tool) with MIME inferred from the extension. One icon, not a multi-resolution set: real clients (the MCP Inspector included) render every entry in the `icons` array side by side instead of picking a best fit. See README "Icons".
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -364,18 +364,20 @@ Both documents are generated from the single `oauth` block, so they can never dr
 
 ## Icons
 
-An agentling can advertise PNG **icons** on its MCP surface so clients can show a recognizable image for the server and its tools. Icons ride on the standard MCP `Icon` type — the server's on `serverInfo.icons`, and one set per tool (the spawn tool named after the agent, and its `__get_task` companion).
+An agentling can advertise **icons** on its MCP surface so clients can show a recognizable image for the server and its tools. Icons ride on the standard MCP `Icon` type — the server's on `serverInfo.icons`, and one per tool (the spawn tool named after the agent, and its `__get_task` companion).
 
 Configure with an `icons` block in `agent.yaml`:
 
 ```yaml
 icons:
-  server: https://cdn.example.com/icons/agentling   # MCP serverInfo icon
-  spawn:  https://cdn.example.com/icons/play         # the main (spawn) tool
-  task:   https://cdn.example.com/icons/task         # the __get_task tool
+  server: https://cdn.example.com/icons/agentling.png   # MCP serverInfo icon
+  spawn:  https://cdn.example.com/icons/play.png         # the main (spawn) tool
+  task:   https://cdn.example.com/icons/task.png         # the __get_task tool
 ```
 
-Each value is a **base URL stem**: the framework appends `-<size>.png` for every size in `ICON_SIZES` — **16, 32, 64, 128, 256, 512** — and emits one `Icon` per resolution so clients pick the best fit for their display. So `server: …/agentling` advertises `agentling-16.png` through `agentling-512.png`; host those six PNGs at the corresponding URLs (any public store/CDN, served as `image/png`). Omit a key — or the whole block — to send no icons for that surface.
+Each value is the **full icon URL** — an HTTPS address or a `data:` URI — served as a single icon that the client scales to fit. The MIME type is inferred from the extension (`.png`, `.jpg`/`.jpeg`, `.svg`, `.webp`); `data:` URIs carry their own. PNG and JPEG are universally supported by clients; SVG and WebP are not guaranteed. Omit a key — or the whole block — to send no icon for that surface.
+
+> We advertise **one icon per surface**, not a multi-resolution set. The spec's `icons` array is meant for clients to pick a best-fit size, but real clients (the MCP Inspector among them) render *every* entry side by side — so a single icon is the only thing that displays cleanly today.
 
 ## Memory
 

--- a/agent.example.yaml
+++ b/agent.example.yaml
@@ -83,9 +83,9 @@ telemetry:
 #   jwks_uri: null                      # optional; derived from OIDC discovery when omitted
 
 # icons:
-#   # PNG icons advertised on the MCP surface (serverInfo + per-tool). Each value
-#   # is a base-URL stem; the framework appends -<size>.png for sizes
-#   # 16/32/64/128/256/512 and emits one Icon per size. See README "Icons".
-#   server: https://cdn.example.com/icons/agentling   # MCP server icon
-#   spawn:  https://cdn.example.com/icons/play         # main (spawn) tool
-#   task:   https://cdn.example.com/icons/task         # __get_task tool
+#   # Icons advertised on the MCP surface (serverInfo + per-tool). Each value is
+#   # the full icon URL (HTTPS or data: URI), served as a single icon the client
+#   # scales to fit; MIME type is inferred from the extension. See README "Icons".
+#   server: https://cdn.example.com/icons/agentling.png   # MCP server icon
+#   spawn:  https://cdn.example.com/icons/play.png         # main (spawn) tool
+#   task:   https://cdn.example.com/icons/task.png         # __get_task tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.13.0"
+version = "0.13.1"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -192,17 +192,19 @@ class OAuthConfig(BaseModel):
 
 
 class IconsConfig(BaseModel):
-    """CDN icon bases advertised on the MCP surface.
+    """Icon URLs advertised on the MCP surface.
 
-    Each value is a base URL to which ``-<size>.png`` is appended for every
-    size in ``agentlings.protocol.mcp.ICON_SIZES`` (16/32/64/128/256/512),
-    producing one MCP ``Icon`` per resolution so clients can pick the best
-    fit. A ``None`` value omits icons for that surface.
+    Each value is the full icon address — an HTTPS URL or a ``data:`` URI —
+    advertised as a single MCP ``Icon`` on the relevant surface. We send one
+    icon per surface rather than a multi-resolution set because real clients
+    (the MCP Inspector included) render every entry in the ``icons`` array
+    side by side instead of selecting a best fit. A ``None`` value omits icons
+    for that surface.
 
     Attributes:
-        server: Base URL for the MCP server icon (``serverInfo.icons``).
-        spawn: Base URL for the main spawn tool's icon.
-        task: Base URL for the ``__get_task`` tool's icon.
+        server: Icon URL for the MCP server (``serverInfo.icons``).
+        spawn: Icon URL for the main spawn tool.
+        task: Icon URL for the ``__get_task`` tool.
     """
 
     model_config = ConfigDict(extra="ignore")

--- a/src/agentlings/protocol/mcp.py
+++ b/src/agentlings/protocol/mcp.py
@@ -38,26 +38,32 @@ from agentlings.core.telemetry import otel_span
 
 logger = logging.getLogger(__name__)
 
-# Resolutions advertised for each MCP icon. The CDN holds one PNG per size,
-# named ``<base>-<size>.png``; clients pick the best fit for their display.
-ICON_SIZES = (16, 32, 64, 128, 256, 512)
+def _icon_set(url: str | None) -> list[Icon] | None:
+    """Wrap a single icon URL in the one-element ``Icon`` list MCP expects.
 
-
-def _icon_set(base: str | None) -> list[Icon] | None:
-    """Expand a CDN icon base into one ``Icon`` per size in ``ICON_SIZES``.
-
-    ``base`` is a URL stem (e.g. ``https://cdn/icons/agentling``) to which
-    ``-<size>.png`` is appended. Returns ``None`` when ``base`` is unset so the
-    ``icons`` field is omitted from the MCP payload entirely rather than sent
-    empty.
+    ``url`` is the full icon address (an HTTPS URL or a ``data:`` URI). We
+    advertise exactly one icon per surface and omit ``sizes`` so any client
+    scales it to fit: the spec's multi-resolution array assumes clients pick a
+    best fit, but real clients (the MCP Inspector among them) render every
+    entry side by side, so a single icon is the only thing that displays
+    cleanly. Returns ``None`` when ``url`` is unset so the ``icons`` field is
+    dropped from the payload rather than sent empty.
     """
-    if not base:
+    if not url:
         return None
-    stem = base.rstrip("/")
-    return [
-        Icon(src=f"{stem}-{size}.png", mimeType="image/png", sizes=[f"{size}x{size}"])
-        for size in ICON_SIZES
-    ]
+    mime = None if url.startswith("data:") else _mime_from_url(url)
+    return [Icon(src=url, mimeType=mime)]
+
+
+def _mime_from_url(url: str) -> str | None:
+    suffix = url.rsplit(".", 1)[-1].lower() if "." in url else ""
+    return {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "svg": "image/svg+xml",
+        "webp": "image/webp",
+    }.get(suffix)
 
 
 def create_mcp_server(

--- a/tests/unit/test_mcp_icons.py
+++ b/tests/unit/test_mcp_icons.py
@@ -1,0 +1,137 @@
+"""Unit tests for MCP icon advertisement.
+
+We advertise exactly one ``Icon`` per surface (server, spawn tool, get_task
+tool). The spec models ``icons`` as a multi-resolution set for clients to pick
+a best fit from, but real clients (the MCP Inspector among them) render every
+entry side by side — so a single icon is the only thing that displays cleanly.
+These tests pin that single-icon contract and the MIME inference.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from a2a.types import AgentCard
+from mcp.types import ListToolsRequest, PaginatedRequestParams
+
+from agentlings.config import AgentConfig
+from agentlings.core.llm import MockLLMClient
+from agentlings.core.loop import MessageLoop
+from agentlings.core.store import JournalStore
+from agentlings.protocol.agent_card import generate_agent_card
+from agentlings.protocol.mcp import _icon_set, _mime_from_url, create_mcp_server
+from agentlings.tools.registry import ToolRegistry
+
+
+def test_icon_set_returns_none_for_unset() -> None:
+    assert _icon_set(None) is None
+    assert _icon_set("") is None
+
+
+def test_icon_set_wraps_single_icon() -> None:
+    icons = _icon_set("https://cdn.example.com/icons/agentling.png")
+    assert icons is not None
+    assert len(icons) == 1
+    icon = icons[0]
+    assert icon.src == "https://cdn.example.com/icons/agentling.png"
+    assert icon.mimeType == "image/png"
+    assert icon.sizes is None
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://x/a.png", "image/png"),
+        ("https://x/a.jpg", "image/jpeg"),
+        ("https://x/a.jpeg", "image/jpeg"),
+        ("https://x/a.svg", "image/svg+xml"),
+        ("https://x/a.webp", "image/webp"),
+        ("https://x/a.PNG", "image/png"),
+        ("https://x/icon", None),
+        ("https://x/a.gif", None),
+    ],
+)
+def test_mime_from_url(url: str, expected: str | None) -> None:
+    assert _mime_from_url(url) == expected
+
+
+def test_icon_set_omits_mime_for_data_uri() -> None:
+    uri = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+    icons = _icon_set(uri)
+    assert icons is not None
+    assert len(icons) == 1
+    assert icons[0].src == uri
+    assert icons[0].mimeType is None
+
+
+def _config_with_icons(tmp_path: Path, tmp_data_dir: Path) -> AgentConfig:
+    agent_yaml = tmp_path / "agent.yaml"
+    agent_yaml.write_text(
+        "name: test-agent\n"
+        "description: A test agent\n"
+        "tools:\n"
+        "  - bash\n"
+        "icons:\n"
+        "  server: https://cdn.example.com/icons/agentling.png\n"
+        "  spawn: https://cdn.example.com/icons/play.png\n"
+        "  task: https://cdn.example.com/icons/task.svg\n"
+    )
+    return AgentConfig(
+        anthropic_api_key="test-key",
+        agent_api_key="test-agent-key",
+        agent_data_dir=tmp_data_dir,
+        agent_llm_backend="mock",
+        agent_config=str(agent_yaml),
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_and_tools_each_advertise_one_icon(
+    tmp_path: Path, tmp_data_dir: Path
+) -> None:
+    config = _config_with_icons(tmp_path, tmp_data_dir)
+    store = JournalStore(tmp_data_dir)
+    tools = ToolRegistry()
+    tools.register_tools(["bash"])
+    llm = MockLLMClient(tool_names=tools.tool_names())
+    loop = MessageLoop(config=config, store=store, llm=llm, tools=tools)
+    agent_card: AgentCard = generate_agent_card(config)
+    server = create_mcp_server(loop=loop, agent_card=agent_card, config=config)
+
+    assert server.icons is not None
+    assert [i.src for i in server.icons] == [
+        "https://cdn.example.com/icons/agentling.png"
+    ]
+
+    handler = server.request_handlers[ListToolsRequest]
+    request = ListToolsRequest(method="tools/list", params=PaginatedRequestParams())
+    result = await handler(request)
+    by_name = {t.name: t for t in result.root.tools}
+
+    spawn = by_name["test-agent"]
+    assert [i.src for i in spawn.icons] == ["https://cdn.example.com/icons/play.png"]
+    assert spawn.icons[0].mimeType == "image/png"
+
+    get_task = by_name["test-agent__get_task"]
+    assert [i.src for i in get_task.icons] == ["https://cdn.example.com/icons/task.svg"]
+    assert get_task.icons[0].mimeType == "image/svg+xml"
+
+
+@pytest.mark.asyncio
+async def test_icons_omitted_when_unconfigured(
+    tmp_data_dir: Path, test_config: AgentConfig
+) -> None:
+    store = JournalStore(tmp_data_dir)
+    tools = ToolRegistry()
+    tools.register_tools(["bash"])
+    llm = MockLLMClient(tool_names=tools.tool_names())
+    loop = MessageLoop(config=test_config, store=store, llm=llm, tools=tools)
+    agent_card: AgentCard = generate_agent_card(test_config)
+    server = create_mcp_server(loop=loop, agent_card=agent_card, config=test_config)
+
+    assert server.icons is None
+    handler = server.request_handlers[ListToolsRequest]
+    request = ListToolsRequest(method="tools/list", params=PaginatedRequestParams())
+    result = await handler(request)
+    assert all(t.icons is None for t in result.root.tools)


### PR DESCRIPTION
The icons feature (0.12.0) emitted one `Icon` per resolution (16–512), but MCP clients render the whole `icons` array side by side rather than picking a best-fit by size — the Inspector's `IconDisplay` maps over every entry and ignores `sizes` entirely. The result was six tiny duplicate icons next to the server name and each tool.

The spec models `icons` as a multi-resolution set for clients to choose from, but no real client does that selection today, so a single icon is the only thing that displays cleanly.

- Emit one `Icon` per surface and omit `sizes` so the client scales it to fit
- `IconsConfig` values are now full icon URLs (HTTPS or `data:` URI), not base stems — MIME type is inferred from the extension (`.png`/`.jpg`/`.svg`/`.webp`); `data:` URIs carry their own
- Updated README, `agent.example.yaml`, and CLAUDE.md to the full-URL form
- Added unit tests pinning the single-icon contract, MIME inference, and server/tool wiring
- Bump 0.13.0 → 0.13.1

Note: deployed `icons:` config must switch from base stems to full URLs with extensions (e.g. `server: https://…/agentling.png`); the framework no longer appends `-<size>.png`.