### PR TITLE
feat: sleep.batch flag — summarize via live calls instead of batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Quick check: were there any conversations today? If not, skip everything. No LLM
 
 ### Phase 2: Deep sleep — replay and file
 
-For each conversation from today, the sleep cycle reads the JSONL journal from the last compaction marker and submits all summaries as a single **batch request** to the Anthropic Message Batches API. Batch processing runs at 50% cost and processes in parallel.
+For each conversation from today, the sleep cycle reads the JSONL journal from the last compaction marker and summarizes it. By default all summaries are submitted as a single **batch request** to the Anthropic Message Batches API — 50% cost, processed in parallel, but may sit for up to the poll timeout (2h). Set `batch: false` to instead run each summary as a sequential live `complete()` call: immediate, full price, and usable against backends that lack the batches API (e.g. Ollama). Pair `batch: false` with `model` to summarize on a cheaper/faster model than the agent's live turns use.
 
 Each summary call receives the agent's system prompt (so the agent's persona shapes what it considers important), current memory, and the conversation content. The LLM returns a structured `ConversationSummary` with a narrative and memory candidates.
 
@@ -468,13 +468,19 @@ Deletes conversation JSONL files older than `conversation_retention_days` and jo
 ```yaml
 sleep:
   schedule: "0 2 * * *"           # cron expression (default: 2am daily)
+  batch: true                      # false → sequential live calls, no batches API
   journal_retention_days: 30       # keep journals for 30 days
   conversation_retention_days: 14  # keep JSONL conversations for 14 days
   memory_max_entries: 50           # hard cap after consolidation
-  # model: null                    # override model for sleep calls
+  # model: null                    # override model for sleep calls (batch + live)
   # summary_prompt: null           # override per-conversation summary prompt
   # consolidation_prompt: null     # override REM consolidation prompt
 ```
+
+When `batch: false`, deep-sleep summaries run one at a time via the live Messages
+API instead of the batches API — slower and full price, but it works on backends
+without a batches endpoint and returns immediately. The `model` override applies to
+both the deep-sleep summaries and the REM consolidation call regardless of `batch`.
 
 ### CLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.13.1"
+version = "0.14.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/config.py
+++ b/src/agentlings/config.py
@@ -42,6 +42,13 @@ class SleepConfig(BaseModel):
         enabled: When ``False``, the sleep cycle is not scheduled even if
             the block is present. Set this for backends that lack the
             Anthropic batches API (e.g. Ollama's compatibility layer).
+        batch: When ``True`` (default), deep-sleep summaries are submitted to
+            the Anthropic Message Batches API (50% cost, parallel, but may sit
+            for up to the poll timeout). When ``False``, each summary is run as
+            a sequential live ``complete()`` call instead — immediate, full
+            price, and usable against backends without a batches API (e.g.
+            Ollama). Combine with ``model`` to run sleep on a cheaper/faster
+            model than the agent uses for live turns.
         schedule: Cron expression for when to run (default 2am daily).
         journal_retention_days: How long to keep journal files.
         conversation_retention_days: How long to keep JSONL conversation files.
@@ -58,6 +65,7 @@ class SleepConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     enabled: bool = True
+    batch: bool = True
     schedule: str = "0 2 * * *"
     journal_retention_days: int = 30
     conversation_retention_days: int = 14

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -209,6 +209,7 @@ class BaseLLMClient(ABC):
         context_id: str | None = None,
         task_id: str | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
         """Send a completion request and return the full response.
 
@@ -225,6 +226,9 @@ class BaseLLMClient(ABC):
             task_id: The task execution this request belongs to. When set, it is
                 forwarded as the ``x-agentling-task-id`` request header so a single
                 task's Messages calls can be isolated within a session.
+            model: Overrides the client's configured model for this call only.
+                Used by the sleep cycle's non-batch path to run summaries on a
+                different model. ``None`` uses the configured model.
 
         Returns:
             The model's response content and stop reason.
@@ -346,10 +350,12 @@ class AnthropicLLMClient(BaseLLMClient):
         context_id: str | None = None,
         task_id: str | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
         effective_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
+        use_model = model or self._model
         kwargs: dict[str, Any] = {
-            "model": self._model,
+            "model": use_model,
             "max_tokens": effective_max_tokens,
             "system": system,
             "messages": messages,
@@ -384,7 +390,7 @@ class AnthropicLLMClient(BaseLLMClient):
 
         with otel_span("agentling.llm.complete", {
             "llm.backend": "anthropic",
-            "llm.model": self._model,
+            "llm.model": use_model,
             "llm.max_tokens": effective_max_tokens,
             "llm.message_count": len(messages),
             "llm.tool_count": len(tools or []),
@@ -399,7 +405,7 @@ class AnthropicLLMClient(BaseLLMClient):
             usage = _extract_usage(response.usage)
             usage_total = record_llm_usage(
                 usage,
-                model=self._model,
+                model=use_model,
                 path="live",
             )
             span.set_attribute("llm.duration_seconds", round(duration, 4))
@@ -413,7 +419,7 @@ class AnthropicLLMClient(BaseLLMClient):
                 content=[block.model_dump() for block in response.content],
                 stop_reason=response.stop_reason,
                 usage=usage,
-                model=self._model,
+                model=use_model,
             )
 
     async def stream(
@@ -580,6 +586,8 @@ class MockLLMClient(BaseLLMClient):
         self.last_context_id: str | None = None
         self.last_task_id: str | None = None
         self.last_max_tokens: int | None = None
+        self.last_model: str | None = None
+        self.complete_calls: int = 0
         # Record the thinking config so tests can assert it was threaded
         # through the factory. The mock backend ignores it for behavior.
         self.thinking_config: ThinkingConfig | None = (
@@ -595,11 +603,14 @@ class MockLLMClient(BaseLLMClient):
         context_id: str | None = None,
         task_id: str | None = None,
         max_tokens: int | None = None,
+        model: str | None = None,
     ) -> LLMResponse:
         self._call_count += 1
+        self.complete_calls += 1
         self.last_context_id = context_id
         self.last_task_id = task_id
         self.last_max_tokens = max_tokens
+        self.last_model = model
         last_message = messages[-1] if messages else {}
         last_text = _extract_text(last_message)
 

--- a/src/agentlings/core/sleep.py
+++ b/src/agentlings/core/sleep.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from agentlings.config import AgentConfig, SleepConfig
-from agentlings.core.llm import BaseLLMClient, BatchRequest
+from agentlings.core.llm import BaseLLMClient, BatchItemResult, BatchRequest
 from agentlings.core.memory_models import (
     ConsolidatedMemory,
     ConversationSummary,
@@ -169,14 +169,10 @@ class SleepCycle:
         if not batch_requests:
             return [], []
 
-        logger.info("[SLEEP:DEEP] Submitting batch of %d summary requests", len(batch_requests))
-
-        batch_ids = await self._llm.batch_create(batch_requests, model=sleep_model)
-
-        all_results = []
-        for batch_id in batch_ids:
-            results = await self._poll_batch(batch_id)
-            all_results.extend(results)
+        if self._sleep_config.batch:
+            all_results = await self._summarize_batched(batch_requests, sleep_model)
+        else:
+            all_results = await self._summarize_live(batch_requests, sleep_model)
 
         summaries: list[str] = []
         all_candidates: list[MemoryCandidate] = []
@@ -211,6 +207,64 @@ class SleepCycle:
             logger.info("[SLEEP:DEEP] Extracted %d memory candidates", len(all_candidates))
 
         return summaries, all_candidates
+
+    async def _summarize_batched(
+        self,
+        batch_requests: list[BatchRequest],
+        sleep_model: str | None,
+    ) -> list[BatchItemResult]:
+        """Summarize via the Anthropic Message Batches API (50% cost, parallel)."""
+        logger.info(
+            "[SLEEP:DEEP] Submitting batch of %d summary requests", len(batch_requests)
+        )
+        batch_ids = await self._llm.batch_create(batch_requests, model=sleep_model)
+        all_results: list[BatchItemResult] = []
+        for batch_id in batch_ids:
+            all_results.extend(await self._poll_batch(batch_id))
+        return all_results
+
+    async def _summarize_live(
+        self,
+        batch_requests: list[BatchRequest],
+        sleep_model: str | None,
+    ) -> list[BatchItemResult]:
+        """Summarize via sequential live ``complete()`` calls — no batch API.
+
+        Used when ``sleep.batch`` is ``False``. Runs one request at a time so it
+        stays gentle on rate limits and works against backends that lack the
+        batches API (e.g. Ollama). A single request failing is recorded as a
+        failed item rather than aborting the run, mirroring the batch path.
+        """
+        logger.info(
+            "[SLEEP:DEEP] Running %d summary requests live on %s (no batch)",
+            len(batch_requests), sleep_model or "agent default model",
+        )
+        results: list[BatchItemResult] = []
+        for req in batch_requests:
+            try:
+                response = await self._llm.complete(
+                    system=req.system,
+                    messages=req.messages,
+                    tools=[],
+                    output_schema=req.output_schema,
+                    max_tokens=req.max_tokens,
+                    model=sleep_model,
+                )
+                results.append(BatchItemResult(
+                    custom_id=req.custom_id,
+                    content=response.content,
+                    status="succeeded",
+                ))
+            except Exception as e:  # noqa: BLE001 — degrade per-item, never abort
+                logger.exception(
+                    "[SLEEP:DEEP] Live summary failed for %s", req.custom_id
+                )
+                results.append(BatchItemResult(
+                    custom_id=req.custom_id,
+                    status="failed",
+                    error=str(e),
+                ))
+        return results
 
     async def _rem(
         self,
@@ -253,6 +307,7 @@ class SleepCycle:
             tools=[],
             output_schema=strict_json_schema(ConsolidatedMemory),
             max_tokens=self._sleep_config.consolidation_max_tokens,
+            model=self._sleep_config.model,
         )
 
         text = self._extract_structured_text(response.content)

--- a/tests/unit/test_sleep.py
+++ b/tests/unit/test_sleep.py
@@ -99,6 +99,83 @@ class TestDeepSleep:
         assert len(summaries) > 0
 
 
+class TestDeepSleepNoBatch:
+    """With ``sleep.batch: false`` the deep-sleep phase must run sequential live
+    ``complete()`` calls and never touch the batches API."""
+
+    @pytest.fixture
+    def no_batch_deps(self, tmp_data_dir: Path, tmp_path: Path):
+        agent_yaml = tmp_path / "agent.yaml"
+        agent_yaml.write_text(
+            "name: sleep-test-agent\n"
+            "description: A test agent for sleep\n"
+            "tools:\n"
+            "  - bash\n"
+            "sleep:\n"
+            "  batch: false\n"
+            "  model: claude-haiku-4-5\n"
+        )
+        config = AgentConfig(
+            anthropic_api_key="test-key",
+            agent_api_key="test-key",
+            agent_data_dir=tmp_data_dir,
+            agent_llm_backend="mock",
+            agent_config=str(agent_yaml),
+        )
+        store = JournalStore(tmp_data_dir)
+        memory = MemoryFileStore(tmp_data_dir)
+        llm = MockLLMClient(tool_names=[])
+        cycle = SleepCycle(config=config, llm=llm, memory_store=memory, store=store)
+        return cycle, store, llm
+
+    def _seed_conversation(self, store: JournalStore, tmp_data_dir: Path, ctx: str) -> None:
+        store.create(ctx)
+        store.append(ctx, MessageEntry(
+            ctx=ctx, role="user",
+            content=[{"type": "text", "text": "hello agent"}],
+        ))
+        path = tmp_data_dir / ctx / "journal.jsonl"
+        yesterday = datetime.now(timezone.utc) - timedelta(hours=12)
+        import os
+        os.utime(path, (yesterday.timestamp(), yesterday.timestamp()))
+
+    async def test_live_path_calls_complete_not_batch(
+        self, no_batch_deps, tmp_data_dir: Path
+    ) -> None:
+        cycle, store, llm = no_batch_deps
+        self._seed_conversation(store, tmp_data_dir, "ctx-1")
+        self._seed_conversation(store, tmp_data_dir, "ctx-2")
+
+        conversations = cycle._light_sleep(datetime.now(timezone.utc))
+        date_str = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+        summaries, _ = await cycle._deep_sleep(conversations, date_str)
+
+        # One live completion per conversation, and no batch was ever submitted.
+        assert llm.complete_calls == 2
+        assert llm._batch_store == {}
+        # The configured sleep model override is forwarded to complete().
+        assert llm.last_model == "claude-haiku-4-5"
+        # Journal still produced.
+        assert (tmp_data_dir / "journals" / f"{date_str}.md").exists()
+        assert len(summaries) == 2
+
+    async def test_batch_default_uses_batch_api(
+        self, sleep_deps, tmp_data_dir: Path
+    ) -> None:
+        """The default config (batch unset) must still go through the batch API
+        and not fall back to live calls — guards against flipping the default."""
+        cycle, store, _, _ = sleep_deps
+        llm = cycle._llm  # the MockLLMClient from the default sleep_deps fixture
+        self._seed_conversation(store, tmp_data_dir, "ctx-1")
+
+        conversations = cycle._light_sleep(datetime.now(timezone.utc))
+        date_str = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+        await cycle._deep_sleep(conversations, date_str)
+
+        assert llm.complete_calls == 0
+        assert len(llm._batch_store) == 1
+
+
 class TestHousekeeping:
     def test_deletes_old_conversations(self, sleep_deps, tmp_data_dir: Path) -> None:
         cycle, _, _, _ = sleep_deps


### PR DESCRIPTION
## What

Adds a `sleep.batch` config flag (default `true`). When `false`, the deep-sleep phase summarizes each conversation with **sequential live `complete()` calls** instead of submitting them to the Anthropic Message Batches API.

```yaml
sleep:
  batch: false            # live calls, no batches API
  model: claude-haiku-4-5 # optional: summarize on a different model
```

## Why

- **Non-batch backends.** Ollama (and anything behind `ANTHROPIC_BASE_URL`) doesn't implement the batches API — previously the only option was `sleep.enabled: false`. The live path lets sleep run there.
- **Immediacy.** Batches can sit up to the 2h poll timeout; live returns right away for the handful of conversations a day produces.

Default is unchanged (`true` → batches, 50% cost, parallel).

## Changes

- `SleepConfig.batch: bool = True` (config.py)
- `_deep_sleep` branches into `_summarize_batched` / `_summarize_live`; both feed the same `BatchItemResult` parse loop. Per-item failures in the live path degrade gracefully, mirroring the batch path.
- `complete()` gains an optional `model` override (base/Anthropic/mock clients) so the live path can target `sleep.model`. The override now also applies to REM consolidation (no-op when unset).
- Docs + version bump to 0.14.0.

## Tests

- New `TestDeepSleepNoBatch`: asserts the live path calls `complete()` once per conversation, **never** `batch_create`, forwards the `sleep.model` override, and still writes the journal; plus a guard that the default config still uses the batch API.
- Full suite: 579 passed, 5 skipped (clean env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)