### PR TITLE
feat: Agentling-SleepCycle header + span tag on sleep-cycle LLM calls (0.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ Each summary call receives the agent's system prompt (so the agent's persona sha
 
 Results are written to `data/journals/YYYY-MM-DD.md`.
 
+Every LLM request the sleep cycle makes — deep-sleep summaries (live or batch) and the REM consolidation call — carries an `Agentling-SleepCycle: true` request header and an `agentling.sleep_cycle` span attribute, so a gateway or trace backend can isolate sleep-cycle traffic from interactive task turns.
+
 ### Phase 3: REM — integrate and prune
 
 A single LLM call receives current memory, today's journal, and all extracted memory candidates. It integrates new facts, deduplicates, reviews existing entries for staleness, and returns a `ConsolidatedMemory` — the complete updated memory store. Written atomically to `memory.json`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.14.0"
+version = "0.15.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/llm.py
+++ b/src/agentlings/core/llm.py
@@ -114,6 +114,11 @@ def _warn_if_mode_mismatches_model(mode: str, model: str) -> None:
 CONTEXT_ID_HEADER = "x-agentling-context-id"
 TASK_ID_HEADER = "x-agentling-task-id"
 NAME_HEADER = "x-agentling-name"
+# Stamped on every LLM request the nightly sleep cycle makes (live summaries,
+# memory consolidation, and batch submissions) so gateways/proxies can single
+# out sleep-cycle traffic from interactive task traffic. Value is the constant
+# ``"true"`` so a gateway rule can match on equality rather than presence.
+SLEEP_CYCLE_HEADER = "Agentling-SleepCycle"
 
 # Matches ``delay-<seconds>`` in mock user messages — used by integration
 # tests to produce genuinely slow responses without global configuration.
@@ -210,6 +215,7 @@ class BaseLLMClient(ABC):
         task_id: str | None = None,
         max_tokens: int | None = None,
         model: str | None = None,
+        sleep_cycle: bool = False,
     ) -> LLMResponse:
         """Send a completion request and return the full response.
 
@@ -229,6 +235,10 @@ class BaseLLMClient(ABC):
             model: Overrides the client's configured model for this call only.
                 Used by the sleep cycle's non-batch path to run summaries on a
                 different model. ``None`` uses the configured model.
+            sleep_cycle: When ``True``, the request is part of the nightly sleep
+                cycle. It is stamped with the ``Agentling-SleepCycle`` request
+                header and an ``agentling.sleep_cycle`` span attribute so
+                gateways and traces can isolate sleep traffic.
 
         Returns:
             The model's response content and stop reason.
@@ -351,6 +361,7 @@ class AnthropicLLMClient(BaseLLMClient):
         task_id: str | None = None,
         max_tokens: int | None = None,
         model: str | None = None,
+        sleep_cycle: bool = False,
     ) -> LLMResponse:
         effective_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
         use_model = model or self._model
@@ -383,6 +394,8 @@ class AnthropicLLMClient(BaseLLMClient):
             extra_headers[CONTEXT_ID_HEADER] = context_id
         if task_id:
             extra_headers[TASK_ID_HEADER] = task_id
+        if sleep_cycle:
+            extra_headers[SLEEP_CYCLE_HEADER] = "true"
         if beta_header:
             extra_headers[ANTHROPIC_BETA_HEADER] = beta_header
         if extra_headers:
@@ -397,6 +410,7 @@ class AnthropicLLMClient(BaseLLMClient):
             "llm.has_output_schema": bool(output_schema),
             "llm.context_id": context_id or "",
             "llm.task_id": task_id or "",
+            "agentling.sleep_cycle": sleep_cycle,
         }) as span:
             start = time.monotonic()
             response = await self._client.messages.create(**kwargs)
@@ -455,6 +469,7 @@ class AnthropicLLMClient(BaseLLMClient):
             "llm.backend": "anthropic",
             "llm.model": use_model,
             "llm.batch.request_count": len(requests),
+            "agentling.sleep_cycle": True,
         }) as span:
             thinking_cfg = getattr(self, "_thinking", None)
             for i in range(0, len(requests), BATCH_MAX_REQUESTS):
@@ -494,7 +509,10 @@ class AnthropicLLMClient(BaseLLMClient):
                         )
                     )
 
-                result = await self._client.messages.batches.create(requests=api_requests)
+                result = await self._client.messages.batches.create(
+                    requests=api_requests,
+                    extra_headers={SLEEP_CYCLE_HEADER: "true"},
+                )
                 batch_ids.append(result.id)
                 logger.info("batch submitted: %s (%d requests)", result.id, len(chunk))
 
@@ -587,6 +605,7 @@ class MockLLMClient(BaseLLMClient):
         self.last_task_id: str | None = None
         self.last_max_tokens: int | None = None
         self.last_model: str | None = None
+        self.last_sleep_cycle: bool = False
         self.complete_calls: int = 0
         # Record the thinking config so tests can assert it was threaded
         # through the factory. The mock backend ignores it for behavior.
@@ -604,6 +623,7 @@ class MockLLMClient(BaseLLMClient):
         task_id: str | None = None,
         max_tokens: int | None = None,
         model: str | None = None,
+        sleep_cycle: bool = False,
     ) -> LLMResponse:
         self._call_count += 1
         self.complete_calls += 1
@@ -611,6 +631,7 @@ class MockLLMClient(BaseLLMClient):
         self.last_task_id = task_id
         self.last_max_tokens = max_tokens
         self.last_model = model
+        self.last_sleep_cycle = sleep_cycle
         last_message = messages[-1] if messages else {}
         last_text = _extract_text(last_message)
 
@@ -637,6 +658,7 @@ class MockLLMClient(BaseLLMClient):
             "llm.tool_count": len(tools or []),
             "llm.context_id": context_id or "",
             "llm.task_id": task_id or "",
+            "agentling.sleep_cycle": sleep_cycle,
         }) as span:
             if last_message.get("role") == "tool":
                 response = LLMResponse(

--- a/src/agentlings/core/sleep.py
+++ b/src/agentlings/core/sleep.py
@@ -249,6 +249,7 @@ class SleepCycle:
                     output_schema=req.output_schema,
                     max_tokens=req.max_tokens,
                     model=sleep_model,
+                    sleep_cycle=True,
                 )
                 results.append(BatchItemResult(
                     custom_id=req.custom_id,
@@ -308,6 +309,7 @@ class SleepCycle:
             output_schema=strict_json_schema(ConsolidatedMemory),
             max_tokens=self._sleep_config.consolidation_max_tokens,
             model=self._sleep_config.model,
+            sleep_cycle=True,
         )
 
         text = self._extract_structured_text(response.content)

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -11,6 +11,7 @@ from agentlings.core.llm import (
     ANTHROPIC_BETA_HEADER,
     CONTEXT_ID_HEADER,
     NAME_HEADER,
+    SLEEP_CYCLE_HEADER,
     TASK_ID_HEADER,
     AnthropicLLMClient,
     MockLLMClient,
@@ -187,6 +188,85 @@ class TestContextIdHeader:
         )
         assert client.last_context_id == "ctx-xyz"
         assert client.last_task_id == "task-xyz"
+
+
+class TestSleepCycleHeader:
+    """The ``Agentling-SleepCycle`` header marks every LLM request the nightly
+    sleep cycle makes so a gateway/proxy can isolate it from task traffic.
+    """
+
+    def _stub_client(self) -> tuple[AnthropicLLMClient, AsyncMock]:
+        response = MagicMock()
+        response.content = []
+        response.stop_reason = "end_turn"
+        response.usage = None
+        create = AsyncMock(return_value=response)
+        mock_client = MagicMock()
+        mock_client.messages.create = create
+
+        client = AnthropicLLMClient.__new__(AnthropicLLMClient)
+        client._client = mock_client
+        client._model = "claude-sonnet-4-6"
+        client._max_tokens = 128
+        return client, create
+
+    @pytest.mark.asyncio
+    async def test_header_set_when_sleep_cycle(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(system=[], messages=[], tools=[], sleep_cycle=True)
+
+        extra_headers = create.await_args.kwargs["extra_headers"]
+        assert extra_headers == {SLEEP_CYCLE_HEADER: "true"}
+
+    @pytest.mark.asyncio
+    async def test_no_header_when_not_sleep_cycle(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(system=[], messages=[], tools=[])
+
+        assert "extra_headers" not in create.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_header_coexists_with_context_id(self) -> None:
+        client, create = self._stub_client()
+
+        await client.complete(
+            system=[], messages=[], tools=[],
+            context_id="ctx-1", sleep_cycle=True,
+        )
+
+        extra_headers = create.await_args.kwargs["extra_headers"]
+        assert extra_headers == {
+            CONTEXT_ID_HEADER: "ctx-1",
+            SLEEP_CYCLE_HEADER: "true",
+        }
+
+    @pytest.mark.asyncio
+    async def test_batch_create_always_stamps_header(self) -> None:
+        from agentlings.core.llm import BatchRequest
+
+        client, _ = self._stub_client()
+        batch_create = AsyncMock(return_value=MagicMock(id="batch_1"))
+        client._client.messages.batches.create = batch_create
+
+        await client.batch_create([
+            BatchRequest(custom_id="c1", system=[], messages=[]),
+        ])
+
+        extra_headers = batch_create.await_args.kwargs["extra_headers"]
+        assert extra_headers == {SLEEP_CYCLE_HEADER: "true"}
+
+    @pytest.mark.asyncio
+    async def test_mock_records_last_sleep_cycle(self) -> None:
+        client = MockLLMClient()
+        await client.complete(
+            system=[],
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            tools=[],
+            sleep_cycle=True,
+        )
+        assert client.last_sleep_cycle is True
 
 
 class TestNameHeader:


### PR DESCRIPTION
## What

Marks every LLM request the nightly sleep cycle makes so a gateway (sluice) or trace backend can isolate sleep-cycle traffic from interactive task turns.

- **Header** `Agentling-SleepCycle: true` on deep-sleep summaries (live + batch) and the REM consolidation call.
- **Span attribute** `agentling.sleep_cycle` on `agentling.llm.complete` and `agentling.llm.batch_create`.

## Why

Previously sleep-cycle calls were indistinguishable from interactive `/v1/messages` traffic at the gateway — only the static `x-agentling-name` rode along, with no per-call marker for the nightly cycle. This lets sluice add a `Sleep-Cycle` tag via a header-match rule (mirrors the existing `tag-k3s-agentling` rule).

## How

- `llm.py`: `SLEEP_CYCLE_HEADER` constant; `sleep_cycle` flag threaded through `complete()` (abstract + Anthropic + Mock); `batch_create` stamps it unconditionally (batches are only ever created by the sleep cycle).
- `sleep.py`: `_summarize_live` and `_rem` pass `sleep_cycle=True`.
- Value is the constant `"true"` so a gateway rule can match on equality.

## Tests

New `TestSleepCycleHeader`: header presence when `sleep_cycle=True`, absence otherwise, coexistence with `x-agentling-context-id`, `batch_create` stamping, and mock recording. Full unit suite green (clean env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)