### PR TITLE
feat: harden sleep memory prompts — no secrets, hard cap, real dates (0.16.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentlings"
-version = "0.15.0"
+version = "0.16.0"
 description = "Lightweight A2A + MCP single-process agent framework"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/agentlings/core/sleep.py
+++ b/src/agentlings/core/sleep.py
@@ -38,21 +38,39 @@ Extract any facts worth adding to your long-term memory. Only extract NEW facts 
 not already in your current memory. Focus on operational knowledge, patterns, \
 decisions, things that changed. Ignore passing context.
 
+Each candidate must be ONE self-contained fact of at most ~60 words; split \
+multi-topic findings into separate candidates.
+
+NEVER record secret values — API keys, tokens, passwords, access keys. Record \
+only WHERE the credential lives (a secret store / vault reference), never the \
+literal value.
+
 If the conversation was trivial or contained nothing new worth remembering, \
 return an empty memory_candidates list."""
 
 DEFAULT_CONSOLIDATION_PROMPT = """\
-You are performing nightly memory maintenance.
+You are performing nightly memory maintenance. The date of the conversations \
+under review is stated in the message below.
 
 Your job:
-1. Integrate new candidates that add genuine value. Deduplicate against existing entries.
+1. Integrate new candidates that add genuine value. Deduplicate against existing \
+entries, and MERGE multiple entries about the same component into a single entry.
 2. Review every existing entry. Is it still relevant? Has it been superseded by \
 something learned today? Would it help you do your job tomorrow?
-3. Drop anything that is stale, redundant, or no longer operationally useful.
-4. You have a hard limit of {memory_max_entries} entries.
+3. Drop anything stale, redundant, or no longer operationally useful. Exclude \
+pure implementation trivia (library internals, exact schemas, code paths) unless \
+tied to an unresolved incident — that detail lives in the source, not memory.
+4. You MUST return at most {memory_max_entries} entries. If integrating new \
+candidates would exceed the limit, rank every entry by future operational value \
+and drop the lowest-value entries until you are under the cap.
 
-Preserve the recorded timestamp for entries you keep unchanged.
-Set recorded to the current date for new or modified entries."""
+NEVER store secret values — API keys, tokens, passwords, access keys. If an \
+existing entry contains a literal secret, REWRITE it in place to a reference \
+describing where the credential lives, keeping the rest of the entry intact.
+
+Do NOT invent or advance dates. Preserve the recorded timestamp for entries you \
+keep unchanged. For new or modified entries, set recorded to the review date \
+stated in the message — never a future or guessed date."""
 
 
 class SleepCycle:
@@ -297,6 +315,7 @@ class SleepCycle:
         system = build_system_prompt(self._config)
         user_content = (
             f"{consolidation_prompt}\n\n"
+            f"Date of the conversations under review: {date_str}\n\n"
             f"Current memory:\n{memory_text}\n\n"
             f"Today's journal:\n{journal_text}\n\n"
             f"New candidates:\n{candidates_text}"

--- a/tests/unit/test_sleep.py
+++ b/tests/unit/test_sleep.py
@@ -351,3 +351,32 @@ class TestRemTokenBudget:
         assert llm.last_max_tokens == budget, (
             "REM must request the configured consolidation_max_tokens, not the default"
         )
+
+
+class TestRemDateInjection:
+    """REM must hand the model the review date so it never guesses (which produced
+    future-dated `recorded` timestamps in the wild)."""
+
+    async def test_rem_includes_review_date_in_message(
+        self, sleep_config: AgentConfig, tmp_data_dir: Path
+    ) -> None:
+        store = JournalStore(tmp_data_dir)
+        memory = MemoryFileStore(tmp_data_dir)
+        llm = MockLLMClient(tool_names=[])
+        captured: dict[str, object] = {}
+        original = llm.complete
+
+        async def spy(*args, **kwargs):  # noqa: ANN002, ANN003
+            captured["messages"] = kwargs.get("messages")
+            return await original(*args, **kwargs)
+
+        llm.complete = spy  # type: ignore[method-assign]
+        cycle = SleepCycle(config=sleep_config, llm=llm, memory_store=memory, store=store)
+
+        await cycle._rem(
+            summaries=["### ctx-1\na summary"], candidates=[], date_str="2026-05-26"
+        )
+
+        content = captured["messages"][0]["content"]  # type: ignore[index]
+        assert "2026-05-26" in content
+        assert "under review" in content.lower()


### PR DESCRIPTION
## What

Hardens the **default** sleep-cycle prompts (`DEFAULT_SUMMARY_PROMPT` / `DEFAULT_CONSOLIDATION_PROMPT`) + adds a code-level date fix. Mirrors the prompt changes already applied to the k3s-agentling's live `agent.yaml`.

Motivated by a review of that agent's memory, which had: plaintext secrets, ~20 future-dated entries, and 52/50 entries of overlapping/trivia content.

## Changes

- **Secrets** — both prompts forbid storing literal credentials; consolidation rewrites any existing literal secret in place to a reference. Memory is injected into every system prompt (`prompt.py`), so secrets there leak into any content-capturing gateway/telemetry (sluice captures content unbounded).
- **Dates** — `_rem` now injects the review date into the consolidation message, and the prompt forbids inventing/advancing dates. Fixes future-dated `recorded` timestamps the model produced when it had to guess the date.
- **Bloat** — consolidation enforces the entry cap by ranking + evicting, merges duplicate per-component entries, and excludes pure implementation trivia. Replaces the old "when in doubt, keep" bias that pushed memory over its cap.
- **Granularity** — summary prompt now asks for one self-contained fact (~60 words) per candidate.

## Tests

`TestRemDateInjection` asserts the review date reaches the consolidation message. Full unit suite green (540 passed).

## Note

The framework default stays vendor-neutral ("a secret store / vault reference"); the k3s-agentling's live `agent.yaml` names the dwvault credential-manager skill specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)