### PR TITLE
fix: make A2A tasks/cancel actually cancel tasks

### DIFF
--- a/src/agentlings/protocol/a2a.py
+++ b/src/agentlings/protocol/a2a.py
@@ -18,6 +18,11 @@ case the executor passes ``await_seconds=0`` to the engine and a ``Task``
 object is enqueued without blocking.
 
 Cancellation (``CancelTask``) hits the engine's cancel path by task id.
+Engine cancellation is cooperative — the worker observes the flag at its
+next checkpoint — so the executor waits up to ``AGENT_TASK_AWAIT_SECONDS``
+for the task to reach a terminal state before answering; the A2A SDK only
+reports a successful cancel when the returned Task is already
+``TASK_STATE_CANCELED``.
 """
 
 from __future__ import annotations
@@ -364,6 +369,22 @@ class AgentlingExecutor(AgentExecutor):
         ``RequestContext.task_id`` is populated from the inbound request,
         which (for our clients) is the engine's task_id — the Task object
         enqueued on the slow path carries that id directly.
+
+        Engine cancellation is cooperative: ``engine.cancel`` flips a flag
+        that the worker observes at its next checkpoint, so the state it
+        returns is usually still ``cancelling`` (mapped to
+        ``TASK_STATE_WORKING`` on the wire). The SDK's ``on_cancel_task``
+        treats anything other than ``TASK_STATE_CANCELED`` as a failed
+        cancel, so after requesting cancellation we wait up to the
+        configured await window for the task to actually reach a terminal
+        state and enqueue that. If the task raced to completion instead,
+        the terminal state is reported honestly and the SDK surfaces
+        ``TaskNotCancelableError`` to the client.
+
+        The result is enqueued as a ``TaskStatusUpdateEvent`` (matching the
+        SDK's own ``TaskUpdater.cancel``) — enqueueing a full ``Task`` is
+        discarded by the SDK's task manager as an attempted task
+        replacement, since the task already exists in the store.
         """
         task_id = context.task_id
         with otel_span("agentling.a2a.cancel", {
@@ -384,6 +405,15 @@ class AgentlingExecutor(AgentExecutor):
 
             try:
                 state = await self._engine.cancel(task_id=task_id)
+                if state.status not in TERMINAL_STATUSES:
+                    # Cooperative cancel accepted but not yet observed —
+                    # wait for the worker to hit its next checkpoint and
+                    # write the terminal markers.
+                    state = await self._engine.poll(
+                        task_id=task_id,
+                        wait_seconds=self._await_seconds,
+                        cap_seconds=self._await_seconds,
+                    )
             except TaskNotFoundError:
                 span.set_attribute("a2a.outcome", "not_found")
                 await event_queue.enqueue_event(
@@ -407,9 +437,20 @@ class AgentlingExecutor(AgentExecutor):
                 return
 
             span.set_attribute("task.status", state.status.value)
-            span.set_attribute("a2a.outcome", "cancelled")
-            # Enqueue the updated Task so the SDK relays the cancelled state.
-            await event_queue.enqueue_event(task_state_to_a2a_task(state))
+            span.set_attribute(
+                "a2a.outcome",
+                "cancelled"
+                if state.status == TaskStatus.CANCELLED
+                else f"cancel_{state.status.value}",
+            )
+            # Enqueue a status update so the SDK relays the cancelled state.
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=state.task_id,
+                    context_id=state.context_id,
+                    status=task_state_to_a2a_task(state).status,
+                )
+            )
             await event_queue.close()
 
 

--- a/tests/integration/test_task_flow.py
+++ b/tests/integration/test_task_flow.py
@@ -186,20 +186,49 @@ class TestA2ANativeTaskFlow:
         )
 
     @pytest.mark.asyncio
-    async def test_cancel_task_routes_to_engine(
+    async def test_cancel_working_task_returns_canceled_task(
         self, slow_a2a_client: A2ATestClient
     ) -> None:
-        result = await slow_a2a_client.send("hi")
+        """A ``tasks/cancel`` against a working task must succeed and return
+        the task in ``canceled`` state.
+
+        ``delay-3`` outlasts the server's 2s await window, so the send
+        yields a working task; the worker observes the cooperative cancel
+        flag when the mock LLM's delay elapses (~1s after the cancel), well
+        inside the cancel handler's own await window.
+        """
+        result = await slow_a2a_client.send("delay-3 long running work")
         assert isinstance(result, A2AResponse)
         task_id = result.raw["task_id"]
         assert task_id is not None
+        assert result.raw["task_state"] == "working"
 
         cancel_resp = await slow_a2a_client.cancel_task(task_id)
-        # Either the task was already terminal (cannot cancel → error) or the
-        # cancel succeeded and returned the cancelled task. Both are valid
-        # depending on timing; what matters is the wire works and we don't
-        # crash.
-        assert "result" in cancel_resp or "error" in cancel_resp
+        task_obj = cancel_resp.get("result")
+        assert task_obj is not None, f"cancel was rejected: {cancel_resp}"
+        assert task_obj["id"] == task_id
+        assert task_obj["status"]["state"] == "canceled"
+
+        # GetTask must agree that the task is terminally cancelled.
+        get_resp = await slow_a2a_client.get_task(task_id)
+        assert get_resp["result"]["status"]["state"] == "canceled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_completed_task_yields_error(
+        self, slow_a2a_client: A2ATestClient
+    ) -> None:
+        """Cancelling an already-completed task is rejected per the A2A spec
+        (``TaskNotCancelableError``), not silently accepted."""
+        result = await slow_a2a_client.send("hello")
+        assert isinstance(result, A2AResponse)
+        task_id = result.raw["task_id"]
+        assert task_id is not None
+        assert result.raw["task_state"] == "completed"
+
+        cancel_resp = await slow_a2a_client.cancel_task(task_id)
+        assert "error" in cancel_resp, (
+            f"cancel of terminal task should error: {cancel_resp}"
+        )
 
 
 async def _poll_until_terminal(

--- a/tests/unit/test_a2a_executor.py
+++ b/tests/unit/test_a2a_executor.py
@@ -1,8 +1,10 @@
 """Tests for ``AgentlingExecutor`` covering the A2A SendMessage entrypoint.
 
 Focus is on protocol-level wiring: that ``configuration.return_immediately``
-is honored as a per-request opt-out of the await window, and that the
-default behavior continues to block until ``AGENT_TASK_AWAIT_SECONDS``.
+is honored as a per-request opt-out of the await window, that the default
+behavior continues to block until ``AGENT_TASK_AWAIT_SECONDS``, and that
+``CancelTask`` waits for the cooperative cancel to land so the SDK sees a
+``TASK_STATE_CANCELED`` task rather than rejecting the cancel.
 """
 
 from __future__ import annotations
@@ -292,6 +294,237 @@ class TestReturnImmediately:
         assert isinstance(events[0], Message), (
             f"fast path should return Message, got {type(events[0]).__name__}"
         )
+
+
+async def _cancel_and_drain(
+    executor: AgentlingExecutor,
+    ctx: RequestContext,
+    queue: EventQueue,
+    *,
+    timeout: float,
+    while_waiting=None,
+) -> tuple[list[object], float]:
+    """Run ``executor.cancel`` and drain enqueued events concurrently.
+
+    ``while_waiting`` is an optional coroutine function invoked after the
+    cancel call has started — used to unblock the worker's in-flight LLM
+    call so the cooperative cancel can be observed.
+    """
+
+    events: list[object] = []
+
+    async def consumer() -> None:
+        while True:
+            try:
+                event = await queue.dequeue_event()
+            except Exception:  # queue closed
+                return
+            events.append(event)
+            queue.task_done()
+            if queue.is_closed() and queue.queue.empty():
+                return
+
+    start = asyncio.get_event_loop().time()
+    consumer_task = asyncio.create_task(consumer())
+    cancel_task = asyncio.create_task(executor.cancel(ctx, queue))
+    try:
+        if while_waiting is not None:
+            await while_waiting()
+        await asyncio.wait_for(cancel_task, timeout=timeout)
+    finally:
+        try:
+            await asyncio.wait_for(consumer_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            consumer_task.cancel()
+    elapsed = asyncio.get_event_loop().time() - start
+    return events, elapsed
+
+
+def _make_cancel_context(*, context_id: str, task_id: str) -> RequestContext:
+    """Mirror how the SDK's ``on_cancel_task`` builds the RequestContext."""
+    return RequestContext(
+        call_context=ServerCallContext(),
+        request=None,
+        context_id=context_id,
+        task_id=task_id,
+    )
+
+
+class TestCancelTask:
+    @pytest.mark.asyncio
+    async def test_cancel_running_task_yields_canceled_status(
+        self,
+        slow_engine: tuple[TaskEngine, ControllableLLM],
+        test_config: AgentConfig,
+    ) -> None:
+        """Cancelling a working task must enqueue a status update with
+        TASK_STATE_CANCELED — the SDK's ``on_cancel_task`` raises
+        ``TaskNotCancelableError`` for anything else, so enqueueing the
+        immediate ``cancelling`` snapshot (mapped to WORKING) breaks the
+        whole A2A cancel path."""
+        engine, llm = slow_engine
+        test_config.agent_task_await_seconds = 5
+        executor = AgentlingExecutor(_LoopShim(engine), test_config)
+
+        # Start a task that blocks inside the LLM call.
+        await engine.spawn(
+            message="hello",
+            context_id="ctx-cancel",
+            via="a2a",
+            await_seconds=0,
+            task_id="task-cancel",
+        )
+        await asyncio.wait_for(llm.before_call_event.wait(), timeout=2.0)
+
+        async def unblock_worker() -> None:
+            # The worker only observes the cancel flag after the in-flight
+            # LLM call returns, so wait for the flag then release the LLM.
+            for _ in range(200):
+                rec = engine.registry.get("task-cancel")
+                if rec is not None and rec.cancel_flag:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("cancel flag was never raised on the record")
+            llm.push(LLMResponse(
+                content=[{"type": "text", "text": "too late"}],
+                stop_reason="end_turn",
+            ))
+
+        ctx = _make_cancel_context(
+            context_id="ctx-cancel", task_id="task-cancel",
+        )
+        queue = EventQueue()
+        events, _elapsed = await _cancel_and_drain(
+            executor, ctx, queue, timeout=5.0, while_waiting=unblock_worker,
+        )
+
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, TaskStatusUpdateEvent), (
+            f"expected TaskStatusUpdateEvent, got {type(event).__name__}"
+        )
+        assert event.task_id == "task-cancel"
+        assert event.context_id == "ctx-cancel"
+        assert event.status.state == A2ATaskState.TASK_STATE_CANCELED
+
+    @pytest.mark.asyncio
+    async def test_cancel_terminal_task_returns_state_without_waiting(
+        self,
+        tmp_data_dir: Path,
+        test_config: AgentConfig,
+    ) -> None:
+        """Cancelling an already-completed task must return its terminal
+        state immediately, not burn the await window."""
+        from agentlings.core.llm import MockLLMClient
+
+        tools = ToolRegistry()
+        tools.register_tools(["bash", "filesystem"])
+        llm = MockLLMClient(tool_names=tools.tool_names())
+        store = JournalStore(tmp_data_dir)
+        engine = TaskEngine(
+            config=test_config, store=store, llm=llm, tools=tools,
+        )
+        test_config.agent_task_await_seconds = 30
+        executor = AgentlingExecutor(_LoopShim(engine), test_config)
+
+        state = await engine.spawn(
+            message="hello",
+            context_id="ctx-cancel-done",
+            via="a2a",
+            await_seconds=5,
+            task_id="task-cancel-done",
+        )
+        assert state.status.value == "completed"
+
+        ctx = _make_cancel_context(
+            context_id="ctx-cancel-done", task_id="task-cancel-done",
+        )
+        queue = EventQueue()
+        events, elapsed = await _cancel_and_drain(
+            executor, ctx, queue, timeout=5.0,
+        )
+        assert elapsed < 1.0, (
+            f"cancel of terminal task blocked on the await window ({elapsed:.3f}s)"
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], TaskStatusUpdateEvent)
+        assert events[0].status.state == A2ATaskState.TASK_STATE_COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_cancel_unknown_task_reports_not_found(
+        self,
+        slow_engine: tuple[TaskEngine, ControllableLLM],
+        test_config: AgentConfig,
+    ) -> None:
+        engine, _llm = slow_engine
+        executor = AgentlingExecutor(_LoopShim(engine), test_config)
+
+        ctx = _make_cancel_context(
+            context_id="ctx-missing", task_id="task-missing",
+        )
+        queue = EventQueue()
+        events, _elapsed = await _cancel_and_drain(
+            executor, ctx, queue, timeout=5.0,
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], Message)
+        assert "not found" in events[0].parts[0].text
+
+    @pytest.mark.asyncio
+    async def test_sdk_on_cancel_task_returns_canceled_task(
+        self,
+        slow_engine: tuple[TaskEngine, ControllableLLM],
+        test_config: AgentConfig,
+    ) -> None:
+        """Full A2A path: the SDK's ``on_cancel_task`` (the ``tasks/cancel``
+        handler) must resolve to a canceled Task instead of raising
+        ``TaskNotCancelableError``."""
+        from a2a.server.request_handlers import DefaultRequestHandler
+        from a2a.types import CancelTaskRequest
+
+        from agentlings.protocol.a2a_task_store import EngineTaskStore
+        from agentlings.protocol.agent_card import generate_agent_card
+
+        engine, llm = slow_engine
+        test_config.agent_task_await_seconds = 5
+        executor = AgentlingExecutor(_LoopShim(engine), test_config)
+        handler = DefaultRequestHandler(
+            agent_executor=executor,
+            task_store=EngineTaskStore(engine),
+            agent_card=generate_agent_card(test_config),
+        )
+
+        await engine.spawn(
+            message="hello",
+            context_id="ctx-sdk-cancel",
+            via="a2a",
+            await_seconds=0,
+            task_id="task-sdk-cancel",
+        )
+        await asyncio.wait_for(llm.before_call_event.wait(), timeout=2.0)
+
+        cancel_op = asyncio.create_task(
+            handler.on_cancel_task(
+                CancelTaskRequest(id="task-sdk-cancel"), ServerCallContext(),
+            )
+        )
+        for _ in range(200):
+            rec = engine.registry.get("task-sdk-cancel")
+            if rec is not None and rec.cancel_flag:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("cancel flag was never raised on the record")
+        llm.push(LLMResponse(
+            content=[{"type": "text", "text": "too late"}],
+            stop_reason="end_turn",
+        ))
+
+        result = await asyncio.wait_for(cancel_op, timeout=5.0)
+        assert isinstance(result, Task)
+        assert result.id == "task-sdk-cancel"
+        assert result.status.state == A2ATaskState.TASK_STATE_CANCELED
 
 
 class TestStreamingExecution:


### PR DESCRIPTION
## Summary

The plumbing for A2A `tasks/cancel` existed end to end, but the cancel never actually succeeded: every cancel of a working task came back to the client as `TaskNotCancelableError`. Two independent defects in `AgentlingExecutor.cancel` caused this:

1. **It answered too early.** `engine.cancel()` is cooperative — it flips a flag the worker only observes at its next checkpoint and immediately returns a `cancelling` state, which maps to `TASK_STATE_WORKING` on the wire. The A2A SDK's `on_cancel_task` rejects anything that isn't `TASK_STATE_CANCELED`. The executor now waits (via `engine.poll`, up to `AGENT_TASK_AWAIT_SECONDS`) for the task to actually reach a terminal state before answering. A task that races to completion is reported honestly and the SDK rejects the cancel per spec.

2. **It enqueued the wrong event type.** Even once terminal, enqueueing a full `Task` object is silently discarded by the SDK's task manager as an attempted "task replacement" (the task already exists in `EngineTaskStore`), leaving the aggregated result stuck at WORKING. The cancel result is now a `TaskStatusUpdateEvent` — the same shape the SDK's own `TaskUpdater.cancel()` emits.

Engine-side cancellation semantics are unchanged: cancellation stays cooperative, and cancelled tasks still leave only a `TaskCancelled` audit marker on the parent journal.

## Testing

New tests were verified to fail against the pre-fix code before applying the fix.

- **Unit** (`tests/unit/test_a2a_executor.py`): cancel of a running task yields a `TASK_STATE_CANCELED` status update; cancel of an already-terminal task returns immediately without burning the await window; cancel of an unknown task reports not-found; and a full SDK-level test drives `DefaultRequestHandler.on_cancel_task` end to end and asserts it resolves to a canceled Task instead of raising.
- **Integration** (`tests/integration/test_task_flow.py`): the previous cancel test accepted `result` *or* `error` (which is how this slipped through). It now uses a `delay-3` mock task to guarantee a working task, asserts `tasks/cancel` returns the task in `canceled` state over the JSON-RPC wire, that a follow-up `tasks/get` agrees, and that cancelling a completed task errors per spec.
- Full suite: 550 unit tests + 10 task-flow integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdevKtJNqyq8Rbv9jNNcRY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdevKtJNqyq8Rbv9jNNcRY)_